### PR TITLE
Add accountLocations and accountContacts

### DIFF
--- a/docs/3.-Guides/CRM/1-CustomerRelationshipManagement.md
+++ b/docs/3.-Guides/CRM/1-CustomerRelationshipManagement.md
@@ -11,8 +11,8 @@ If you’re anxious to get started right now, why not dive into our API explorer
 ## Recipes
 A lot of the time people know that they want to see improvement but are unsure where to start. Here is a list of ready to go “recipes” that you can either directly leverage or simply gather inspiration for your own integration efforts:
 
-- Triggering external workflows on business creation
-- Adding contacts and customers from an external Marketing System
+- Triggering external workflows on account creation
+- Adding contacts and accounts from an external Marketing System
 
 ## Customer Case Studies
 If you’re not ready to get started with integrations yet, but would like to hear about the experience of some of our customers with these APIs, here are a set of case studies describing the journey of other Vendasta partners who have found success.

--- a/docs/3.-Guides/CRM/Accounts.md
+++ b/docs/3.-Guides/CRM/Accounts.md
@@ -1,0 +1,249 @@
+---
+tags: [accounts, accountLocations, accountContacts]
+---
+# Accounts
+
+An `Account` is the basic record for storing information about an orginization that you have a sustained relationship with. This may include a potential buyer, an existing client, or a past client that has churned.
+
+## Common Actions
+
+### Creating an Account Location
+
+To create a new Account Location make the following call
+
+```json http
+{
+  "method": "post",
+  "url": "https://prod.apigateway.co/platform/accountLocations",
+  "query": {},
+  "headers": {
+    "Authorization": "Bearer <Access Token>",
+    "Content-Type": "application/vnd.api+json"
+  },
+  "body": {
+    "data": {
+      "type": "accountLocations",
+      "attributes": {
+        "name": "Fred's Fish on Young",
+        "address": {
+          "line1": "123 Young St",
+          "line2": "",
+          "city": "Toronto",
+          "stateCode": "ON",
+          "zip": "O2C 4W9",
+          "countryCode": "CA"
+        },
+        "phone": [
+          {
+            "countryCode": "CA",
+            "raw": "1 (555) 323-1234"
+          }
+        ],
+        "serviceAreaBusiness": false
+      },
+      "relationships": {
+        "owner": {
+          "data": {
+            "type": "organizations",
+            "id": "ABC"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+It will return the newly created record including any server populated values. Be sure to save the ID for later.
+
+```json
+{
+    "data": {
+      "type": "accountLocations",
+      "id": "AG-123",
+      "attributes": {
+        "name": "Fred's Fish on Young",
+        "address": {
+          "line1": "123 Young St",
+          "line2": "",
+          "city": "Toronto",
+          "stateCode": "ON",
+          "zip": "O2C 4W9",
+          "countryCode": "CA"
+        },
+        "phone": [
+          {
+            "countryCode": "CA",
+            "raw": "1 (555) 323-1234"
+          }
+        ],
+        "serviceAreaBusiness": false
+      },
+      "relationships": {
+        "owner": {
+          "data": {
+            "type": "organizations",
+            "id": "ABC"
+          }
+        }
+      }
+    },
+    "links": {
+      "self": "https://prod.apigateway.co/platform/accountLocations/AG-123"
+    }
+  }
+```
+
+
+### Creating an Account Contact
+
+When creating a Contact for an Account you may also link that Contact to one or more Locations in the same API call.
+
+```json http
+{
+  "method": "post",
+  "url": "https://prod.apigateway.co/platform/accountContacts",
+  "query": {},
+  "headers": {
+    "Authorization": "Bearer <Token>",
+    "Content-Type": "application/vnd.api+json"
+  },
+  "body": {
+    "data": {
+      "type": "accountContacts",
+      "attributes": {
+        "name": {
+          "first": "Samantha",
+          "last": "Green",
+          "greeting": "Sam"
+        },
+        "phone": {
+          "countryCode": "CA",
+          "raw": "15553061234"
+        },
+        "email": "user@example.com",
+        "languageCode": "en-US"
+      },
+      "relationships": {
+        "owner": {
+          "data": {
+            "type": "organizations",
+            "id": "ABC"
+          }
+        },
+        "locations": {
+          "data": [
+            {
+              "id": "AG-1234",
+              "type": "accountLocations"
+            },
+            {
+              "id": "AG-4567",
+              "type": "accountLocations"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+It will return the newly created record including any server populated values. Be sure to save the ID for later.
+
+```json
+{
+  {
+    "data": {
+      "type": "accountContacts",
+      "id": "U-1234",
+      "attributes": {
+        "name": {
+          "first": "Samantha",
+          "last": "Green",
+          "greeting": "Sam"
+        },
+        "phone": {
+          "countryCode": "CA",
+          "raw": "15553061234"
+        },
+        "email": "user@example.com",
+        "languageCode": "en-US"
+      },
+      "relationships": {
+        "owner": {
+          "data": {
+            "type": "organizations",
+            "id": "ABC"
+          }
+        },
+        "locations": {
+          "links": {
+            "self": "https://prod.apigateway.co/platform/accountContacts/U-1234/relationships/locations"
+          }
+        }
+      },
+      "links":{
+        "self":"https://prod.apigateway.co/platform/accountContacts/U-1234"
+      }
+    }
+  }
+}
+```
+
+## Proposed future actions
+
+### Get a list of your account locations
+
+```json http
+{
+  "method": "get",
+  "url": "https://prod.apigateway.co/platform/accountLocations",
+  "query": {
+    "filter[parent]": "me",
+    "fields[accountLocations]": "name",
+    "page[limit]": 2
+  },
+  "headers": {
+    "Authorization": "Bearer {your token}",
+    "Content-Type": "application/vnd.api+json",
+    "Accept-Encoding": "application/vnd.api+json"
+  }
+}
+```
+
+Will return something like 
+
+```json
+{
+  "data": [
+    {
+      "type": "accountLocations",
+      "id": "AG-1234",
+      "attributes": {
+        "name": "Bill's Bakery"
+      }
+    },
+    {
+      "type": "accountLocations",
+      "id": "AG-5642",
+      "attributes": {
+        "name": "Shane's Snack Hut"
+      }
+    }
+  ],
+  "links": {
+    "first": "https://prod.apigateway.co/platform/accountLocations?page[cursor]=abc",
+    "self": "https://prod.apigateway.co/platform/accountLocations?page[cursor]=klm",
+    "next": "https://prod.apigateway.co/platform/accountLocations?page[cursor]=nop",
+    "last": "https://prod.apigateway.co/platform/accountLocations?page[cursor]=xyz"
+  },
+  "meta": {
+    "total": 234
+  }
+}
+```
+
+### Find a customer using the ID from your external system
+
+Comming soon

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -1,0 +1,507 @@
+openapi: 3.0.0
+info:
+  title: Platform REST APIs
+  version: Evergreen
+servers:
+  - url: 'https://prod.apigateway.co/platform'
+    description: Production
+  - description: Demo
+    url: 'https://demo.apigateway.co/platform'
+  - description: Localhost
+    url: '{localhost}/platform'
+  - url: 'https://vendasta.stoplight.io/mocks/vendasta/openapi-specs/1808816'
+    description: Mock
+paths:
+  /accountContacts:
+    post:
+      summary: Create Account Contact
+      operationId: post-accountContacts
+      responses:
+        '201':
+          description: Created
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/accountContacts'
+                  links:
+                    type: object
+                    properties:
+                      self:
+                        type: string
+                        format: uri
+                        description: The address of the newly created account contact
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: The address of the newly created account contact
+      description: |-
+        Create a new Account Contact. It is recomended that 
+
+        At least one of `name.first`, `name.last`, `phone.raw` or `email` must be provided when creating a contact.
+      security:
+        - OAuth:
+            - sales.contact
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: '#/components/schemas/accountContacts'
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - name.first
+              - name.last
+              - name.greeting
+              - phone
+              - email
+              - owner
+              - locations
+              - languageCode
+          in: query
+          name: 'fields[accountContact]'
+          description: A comma seperated list of fields from the newly created record to be returned in the response.
+        - schema:
+            type: string
+            example: Bearer <Access Token>
+            pattern: ^Bearer\s\S+
+          in: header
+          name: Authorization
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          required: true
+        - schema:
+            type: string
+            default: application/vnd.api+json
+            enum:
+              - application/vnd.api+json
+          in: header
+          name: Content-Type
+          required: true
+          description: Indicates the format of the request body being sent. In most cases you will want `application/vnd.api+json`
+  '/accountContacts/{id}':
+    parameters:
+      - schema:
+          type: string
+        name: id
+        in: path
+        required: true
+        description: The ID of the contact to be returned
+    get:
+      summary: Get Account Contact
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/accountContacts'
+                  links:
+                    type: object
+                    properties:
+                      self:
+                        type: string
+      operationId: get-accountContacts-id
+      security:
+        - OAuth:
+            - sales.contact
+      description: Fetch the current values for the specified account contact
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - name.first
+              - name.last
+              - name.greeting
+              - phone
+              - email
+              - owner
+              - locations
+              - languageCode
+          in: query
+          name: 'fields[accountContact]'
+          description: A comma seperated list of fields from the newly created record to be returned in the response.
+        - schema:
+            type: string
+            example: Bearer <Access Token>
+            pattern: ^Bearer\s\S+
+          in: header
+          name: Authorization
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          required: true
+  '/accountContacts/{contactID}/relationships/locations':
+    parameters:
+      - schema:
+          type: string
+        name: contactID
+        in: path
+        required: true
+  /accountLocations:
+    post:
+      summary: Create Account Location
+      operationId: post-accountLocations
+      responses:
+        '201':
+          description: Created
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/accountLocations'
+                  links:
+                    type: object
+                    properties:
+                      self:
+                        type: string
+                        format: uri
+                        description: The address of the newly created account location
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+              description: The address of the newly created account contact
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: '#/components/schemas/accountLocations'
+      description: |-
+        Used to record basic data for a new location.
+
+        The following members must be populated during creation:
+        - `relationships.owner.data.id`
+        - `relationships.market.data.id`
+        - `attributes.name`
+        - `attributes.address.countryCode` as well as other address fields based on the norms of the country.
+        - `relationships.categories.data.[].id` - At least one category must be provided
+      parameters:
+        - schema:
+            type: string
+            example: Bearer <Access Token>
+            pattern: ^Bearer\s\S+
+          in: header
+          name: Authorization
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          required: true
+        - schema:
+            type: string
+            enum:
+              - name
+              - address.line1
+              - address.line2
+              - address.city
+              - address.zip
+              - address.state
+              - address.countryCode
+              - phone
+              - owner
+          in: query
+          name: 'fields[accountLocations]'
+          description: A comma seperated list of fields from the newly created record to be returned in the response.
+        - schema:
+            type: string
+            default: application/vnd.api+json
+            enum:
+              - application/vnd.api+json
+          in: header
+          name: Content-Type
+          required: true
+          description: Indicates the format of the request body being sent. In most cases you will want `application/vnd.api+json`
+      security:
+        - OAuth:
+            - account
+  '/accountLocations/{id}':
+    parameters:
+      - schema:
+          type: string
+        name: id
+        in: path
+        required: true
+    get:
+      summary: Get Account Location
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/accountLocations'
+                  links:
+                    type: object
+                    properties:
+                      self:
+                        type: string
+      operationId: get-accountLocations-id
+      description: Returns basic data about the account location.
+      parameters:
+        - schema:
+            type: string
+            example: Bearer <Access Token>
+            pattern: ^Bearer\s\S+
+          in: header
+          name: Authorization
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          required: true
+      security:
+        - OAuth:
+            - account
+components:
+  securitySchemes:
+    JWT:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    OAuth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://sso-api-demo.apigateway.co/oauth2/auth'
+          tokenUrl: 'https://sso-api-demo.apigateway.co/oauth2/token'
+          scopes:
+            sales.contact: Read-write access to sales contact details
+            account: Read-write access to account details
+  schemas:
+    accountLocations:
+      title: Account Location
+      type: object
+      description: |
+        Any entity that works with a provider company (two-way communication). These generally have a sustained relationship with the provider company. This may include a potential buyer, an existing client, or a past client that has churned.
+      properties:
+        id:
+          type: string
+          example: AG-1234567
+        type:
+          type: string
+          default: accountLocations
+          enum:
+            - accountLocations
+        attributes:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The common name for this location
+            address:
+              type: object
+              properties:
+                line1:
+                  type: string
+                line2:
+                  type: string
+                city:
+                  type: string
+                state:
+                  type: string
+                zip:
+                  type: string
+                countryCode:
+                  type: string
+                  maxLength: 2
+                  minLength: 2
+                  example: CA
+                  description: 'The two letter country code defined by ISO 3166-1 https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes'
+            phone:
+              type: array
+              items:
+                type: object
+                properties:
+                  countryCode:
+                    type: string
+                    description: An optional 2 character country code used to aid in parcing the raw number. If not specified the value from address.countryCode will be assumed.
+                    maxLength: 2
+                    minLength: 2
+                  raw:
+                    type: string
+                    description: |-
+                      The complete phone number for the location.
+                      Formating characters may be included. 
+
+                      **Extentions**
+
+                      It is recommended that extentions are included at the end of the number after an appropriate seperator: Pause: `,` Wait: `;` Default: `ext.`
+
+                      You may test the parsibility of a number using https://phonenumbers.temba.io/
+                required:
+                  - raw
+            serviceAreaBusiness:
+              type: boolean
+              description: When true the address will be used as the center of the area that this location services instead of being displayed.
+        relationships:
+          type: object
+          properties:
+            owner:
+              type: object
+              description: A link to the organization that owns this record. Account Locations are typically owned by a partner.
+              properties:
+                data:
+                  type: object
+                  required:
+                    - type
+                    - id
+                  properties:
+                    type:
+                      type: string
+                      default: organizations
+                      enum:
+                        - organizations
+                    id:
+                      type: string
+                      example: ABC
+              required:
+                - data
+    accountContacts:
+      title: Account Contact
+      type: object
+      description: |-
+        An account contact is a person who works for the account that your sales, fulfillment, billing and support teams may send communications to reguarding the account.
+
+        At least one of `name.first`, `name.last`, `phone.raw` or `email` must be provided when creating a contact.
+      properties:
+        type:
+          type: string
+          default: accountContacts
+          example: accountContacts
+          enum:
+            - accountContacts
+        id:
+          type: string
+          description: The id will be assigned by the server and must be included on all update requests. Values sent during creation will be ignored.
+        attributes:
+          type: object
+          properties:
+            name:
+              type: object
+              properties:
+                first:
+                  type: string
+                  maxLength: 25
+                  description: The given name of the contact
+                last:
+                  type: string
+                  maxLength: 25
+                  description: The surname of the contact
+                greeting:
+                  type: string
+                  maxLength: 25
+                  description: The name to use in email messages. Defaults to first name.
+            phone:
+              type: object
+              description: The primary phone number for the contact
+              properties:
+                countryCode:
+                  type: string
+                  description: 'An optional 2 character country code used to aid in parcing the raw number. '
+                  maxLength: 2
+                  minLength: 2
+                raw:
+                  type: string
+                  description: |-
+                    The complete primary phone number for the contact.
+                    Formating characters may be included. 
+
+                    **Extentions**
+
+                    It is recommended that extentions are included at the end of the number after an appropriate seperator: Pause: `,` Wait: `;` Default: `ext.`
+
+                    You may test the parsibility of a number using https://phonenumbers.temba.io/
+              required:
+                - raw
+            email:
+              type: string
+              format: email
+              description: The primary email address for the contact
+            languageCode:
+              type: string
+              default: en-US
+              enum:
+                - en-US
+                - cs-CZ
+                - fr-FR
+                - nl-NL
+              description: |-
+                The local language that communications to this contact should be sent in. 
+                Note: We currently have a limited set of allowed languages but expect to support many more in the future.
+        relationships:
+          type: object
+          properties:
+            owner:
+              type: object
+              description: A link to the organization that owns this record. Account Contacts are typically owned by a partner.
+              properties:
+                data:
+                  type: object
+                  required:
+                    - type
+                    - id
+                  properties:
+                    type:
+                      type: string
+                      default: organizations
+                      enum:
+                        - organizations
+                    id:
+                      type: string
+                      example: ABC
+              required:
+                - data
+            locations:
+              type: object
+              description: The account locations that this contact has a connection to
+              properties:
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        example: AG-1234
+                      type:
+                        type: string
+                        default: accountLocations
+                        enum:
+                          - accountLocations
+                    required:
+                      - id
+                      - type
+                links:
+                  type: object
+                  description: Readonly
+                  properties:
+                    self:
+                      type: string
+                      format: uri
+                      example: 'https://prod.apigateway.co/platform/accountContacts/U-123/relationships/locations'
+                    next:
+                      type: string
+                      format: uri
+                      example: 'https://prod.apigateway.co/platform/accountContacts/U-123/relationships/locations?page[cursor]=567'
+                meta:
+                  type: object
+                  properties:
+                    total:
+                      type: integer
+                      description: 'Readonly: The total number of locations connected to this contact'
+      required:
+        - type

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -208,9 +208,9 @@ paths:
               - address.line2
               - address.city
               - address.zip
-              - address.state
+              - address.stateCode
               - address.countryCode
-              - phone
+              - phoneNumbers
               - owner
           in: query
           name: 'fields[accountLocations]'
@@ -255,6 +255,21 @@ paths:
       operationId: get-accountLocations-id
       description: Returns basic data about the account location.
       parameters:
+        - schema:
+            type: string
+            enum:
+              - name
+              - address.line1
+              - address.line2
+              - address.city
+              - address.zip
+              - address.stateCode
+              - address.countryCode
+              - phoneNumbers
+              - owner
+          in: query
+          name: 'fields[accountLocations]'
+          description: A comma seperated list of fields from the newly created record to be returned in the response.
         - schema:
             type: string
             example: Bearer <Access Token>
@@ -311,8 +326,12 @@ components:
                   type: string
                 city:
                   type: string
-                state:
+                stateCode:
                   type: string
+                  maxLength: 2
+                  minLength: 2
+                  example: CA
+                  description: 'The two letter state code within the country'
                 zip:
                   type: string
                 countryCode:
@@ -321,7 +340,7 @@ components:
                   minLength: 2
                   example: CA
                   description: 'The two letter country code defined by ISO 3166-1 https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes'
-            phone:
+            phoneNumbers:
               type: array
               items:
                 type: object

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -7,10 +7,12 @@ servers:
     description: Production
   - description: Demo
     url: 'https://demo.apigateway.co/platform'
-  - description: Localhost
-    url: '{localhost}/platform'
+  - description: Local
+    url: '{local}/platform'
   - url: 'https://vendasta.stoplight.io/mocks/vendasta/openapi-specs/1808816'
     description: Mock
+  - url: 'http://localhost:11001/platform'
+    description: Localhost
 paths:
   /accountContacts:
     post:
@@ -140,6 +142,45 @@ paths:
           name: Authorization
           description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
           required: true
+  '/accountContacts/{contactID}/locations':
+    parameters:
+      - schema:
+          type: string
+        name: contactID
+        in: path
+        required: true
+    get:
+      summary: List Locations related to Contact
+      tags:
+        - accountContacts
+      responses:
+        '200':
+          description: OK
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/accountLocations'
+      operationId: get-accountContacts-contactID-locations
+      description: |-
+        `Proposed`
+        Returns a list of locations that are related to the contact
+      security:
+        - OAuth:
+            - sales.contact
+      parameters:
+        - schema:
+            type: string
+            example: Bearer <Access Token>
+            pattern: ^Bearer\s\S+
+          in: header
+          name: Authorization
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          required: true
   '/accountContacts/{contactID}/relationships/locations':
     parameters:
       - schema:
@@ -147,6 +188,218 @@ paths:
         name: contactID
         in: path
         required: true
+    get:
+      summary: List Location IDs related to Contact
+      operationId: get-accountContacts-contactID-relationships-locations
+      responses:
+        '200':
+          description: OK
+          content:
+            application/vnd.api+json:
+              schema:
+                description: ''
+                type: object
+                properties:
+                  data:
+                    type: array
+                    uniqueItems: true
+                    minItems: 1
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - accountLocations
+                          default: accountLocations
+                        id:
+                          type: string
+                          example: AG-123
+                      required:
+                        - type
+                        - id
+                  links:
+                    type: object
+                    required:
+                      - related
+                      - self
+                    properties:
+                      related:
+                        type: string
+                        format: uri
+                      self:
+                        type: string
+                        format: uri
+                required:
+                  - data
+                  - links
+      security:
+        - OAuth:
+            - sales.contact
+      description: |-
+        `Proposed`
+        Lists the IDs of the Account Locations that are related to this Account Contact
+      tags:
+        - accountContacts
+      parameters:
+        - schema:
+            type: string
+            example: Bearer <Access Token>
+            pattern: ^Bearer\s\S+
+          in: header
+          name: Authorization
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          required: true
+    post:
+      summary: Add locations to contact
+      operationId: post-accountContacts-contactID-relationships-locations
+      responses:
+        '200':
+          description: OK
+      description: |-
+        `Proposed`
+        Adds the listed account locations to the specified account contact. Locations that are already linked will be ignored. 
+      security:
+        - OAuth:
+            - sales.contact
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              description: ''
+              type: object
+              properties:
+                data:
+                  type: array
+                  uniqueItems: true
+                  minItems: 1
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - accountLocations
+                      id:
+                        type: string
+                        example: AG-123
+                    required:
+                      - type
+                      - id
+              required:
+                - data
+      tags:
+        - accountContacts
+      parameters:
+        - schema:
+            type: string
+            example: Bearer <Access Token>
+            pattern: ^Bearer\s\S+
+          in: header
+          name: Authorization
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          required: true
+        - schema:
+            type: string
+            default: application/vnd.api+json
+            enum:
+              - application/vnd.api+json
+          in: header
+          name: Content-Type
+          required: true
+          description: Indicates the format of the request body being sent. In most cases you will want `application/vnd.api+json`
+    patch:
+      summary: Set Locations for Contact
+      operationId: patch-accountContacts-contactID-relationships-locations
+      responses:
+        '200':
+          description: OK
+      description: |-
+        `Proposed`
+        Replaces all existing locations for the contact with the new list.
+
+        Note: This can be completed as a single action with updating the contact's other attributes.
+      tags:
+        - accountContacts
+      security:
+        - OAuth:
+            - sales.contact
+      parameters:
+        - schema:
+            type: string
+            example: Bearer <Access Token>
+            pattern: ^Bearer\s\S+
+          in: header
+          name: Authorization
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          required: true
+        - schema:
+            type: string
+            default: application/vnd.api+json
+            enum:
+              - application/vnd.api+json
+          in: header
+          name: Content-Type
+          required: true
+          description: Indicates the format of the request body being sent. In most cases you will want `application/vnd.api+json`
+    delete:
+      summary: Remove locations from contact
+      operationId: delete-accountContacts-contactID-relationships-locations
+      responses:
+        '204':
+          description: No Content
+      description: |-
+        `Proposed`
+        Removes the specified location(s) from the contact. Locations that have already been removed will be ignored.
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              description: ''
+              type: object
+              properties:
+                data:
+                  type: array
+                  uniqueItems: true
+                  minItems: 1
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - accountLocations
+                      id:
+                        type: string
+                        example: AG-123
+                    required:
+                      - type
+                      - id
+              required:
+                - data
+      tags:
+        - accountContacts
+      security:
+        - OAuth:
+            - sales.contact
+      parameters:
+        - schema:
+            type: string
+            example: Bearer <Access Token>
+            pattern: ^Bearer\s\S+
+          in: header
+          name: Authorization
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          required: true
+        - schema:
+            type: string
+            default: application/vnd.api+json
+            enum:
+              - application/vnd.api+json
+          in: header
+          name: Content-Type
+          required: true
+          description: Indicates the format of the request body being sent. In most cases you will want `application/vnd.api+json`
   /accountLocations:
     post:
       summary: Create Account Location
@@ -227,6 +480,8 @@ paths:
       security:
         - OAuth:
             - account
+      tags:
+        - accountLocations
   '/accountLocations/{id}':
     parameters:
       - schema:
@@ -236,7 +491,8 @@ paths:
         required: true
     get:
       summary: Get Account Location
-      tags: []
+      tags:
+        - accountLocations
       responses:
         '200':
           description: OK
@@ -331,7 +587,7 @@ components:
                   maxLength: 2
                   minLength: 2
                   example: CA
-                  description: 'The two letter state code within the country'
+                  description: The two letter state code within the country
                 zip:
                   type: string
                 countryCode:
@@ -524,3 +780,6 @@ components:
                       description: 'Readonly: The total number of locations connected to this contact'
       required:
         - type
+tags:
+  - name: accountContacts
+  - name: accountLocations


### PR DESCRIPTION
Document basic create account group and create contact endpoints. Terms are based on @jmartens-va's [recommendations](https://vendasta.jira.com/wiki/spaces/~531910978/pages/716996992/RFC+Default+terms+Accounts+and+user+types) 

This is a minimal set of functionality to support the requirements [here](https://vendasta.jira.com/wiki/spaces/API/pages/717325047). List and update endpoints will come later.

For a more pleasant viewing experience, you can check out this branch then use the desktop app https://stoplight.io/studio/ to open the repo. Feel free to leave comments on this PR but keep in mind it is a public repo. 

@vendasta/external-apis @vendasta/psycho-billers 
EA-21