### PR TITLE
Add orders guides

### DIFF
--- a/docs/Guides/Sell/FindSKU.md
+++ b/docs/Guides/Sell/FindSKU.md
@@ -1,6 +1,6 @@
 # Find a SKU
 
-We currently only support creating orders for products that don't include order forms. An API to list the SKUs from your store will be comming. In the mean time please use this list or reachout to support if you can't find a product you are looking for.
+We currently only support creating orders for products that don't include order forms. An API to list the SKUs from your store will be comming. In the mean time please use this list or reachout to support@vendasta.com if you can't find a product you are looking for.
 
 The SKU is typically different between the demo and production environments so be sure to use the correct values.
 
@@ -18,37 +18,23 @@ Product SKUs start with `MP-`. Example: `MP-c4974d390a044c28aec31e421aa662b2`
 
 Addon SKUs start with `A-`. Example: `A-GMXXNQ4ZGD`
 
+## Vendasta Products
 
-
-## Vendasta's Products
+### Reputation Management
 
 Product | Production SKU | Demo SKU
 --------|----------------|---------
- Customer Voice \| Express | MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS | MP-fba21121b71148c9bb33e11fcd92d520:EDITION-4WWZC3RJ
- Customer Voice \| Pro | MP-c4974d390a044c28aec31e421aa662b2:EDITION-VENDASTAPRO | MP-fba21121b71148c9bb33e11fcd92d520:EDITION-VENDASTAPRO
- Listing Builder | MS | MS
- Listing Distribution | A-GMXXNQ4ZGD | A-FR5P5ND7KN
- Listing Sync Pro \| Australia | A-XQL2HMD6VV | A-WQF6NBH4LB 
- Social Marketing | TODO:TODO | TODO:TODO 
- Reputation Management | TODO:TODO | TODO:TODO 
- Website \| Pro | TODO:TODO | TODO:TODO 
- Advertising Inteligence | TODO:TODO | TODO:TODO 
- Others...|TODO|TODO
+ Express |RM:EDITION-F7JZ5TV8 | RM:EDITION-38SMW45H
+ Pro | RM:EDITION-VENDASTAPRO | RM:EDITION-VENDASTAPRO
 
+### Social Marketing
 
-
-> or
-
-
-## Vendasta
-
-### Customer Voice
 Product | Production SKU | Demo SKU
 --------|----------------|---------
- Express |MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS | TODO:TODO
- Pro | MP-c4974d390a044c28aec31e421aa662b2:EDITION-VENDASTAPRO | TODO:TODO
+ Express |SM:EDITION-FVGBNLVZ | SM:EDITION-SWVF3WH8
+ Pro | SM:EDITION-VENDASTAPRO | SM:EDITION-VENDASTAPRO
 
- ### Listing Builder
+### Listing Builder
 
 Product | Production SKU | Demo SKU
 --------|----------------|---------
@@ -58,8 +44,97 @@ Product | Production SKU | Demo SKU
 
 Addon | Production SKU | Demo SKU
 --------|----------------|---------
- Listing Distribution | A-GMXXNQ4ZGD | TODO
- Listing Sync Pro \| Australia | A-XQL2HMD6VV | TODO 
+Listing Distribution | A-GMXXNQ4ZGD | N/A
+Listing Distribution \| Monthly | A-SX5MP2FB2L | N/A
+Listing Sync Pro \| Australia Yearly | A-XQL2HMD6VV | N/A
+Listing Sync Pro \| Australia Monthly | A-P3XFBZ6HCC | N/A
+Listing Sync Pro \| Canada Yearly | A-2BRLL3FH4K | N/A
+Listing Sync Pro \| Canada Monthly | A-C8GSD6X4D2 | N/A
+Listing Sync Pro \| Canada Basic Yearly | A-TD5HVH6LHM | N/A
+Listing Sync Pro \| Canada Basic Monthly | A-Z6S5D3QGHF | N/A
+Listing Sync Pro \| France Yearly | A-C6CNBPXPCC | N/A
+Listing Sync Pro \| France Monthly | A-VM8PJZ8PZ5 | N/A
+Listing Sync Pro \| Germany Yearly | A-W2GGC7TJW3 | N/A
+Listing Sync Pro \| Germany Monthly | A-JZGCTTMHLG | N/A
+Listing Sync Pro \| Italy Yearly | A-KK3MNLFDP5 | N/A
+Listing Sync Pro \| Italy Monthly | A-CDFBK8XW2W | N/A
+Listing Sync Pro United States Yearly | A-TMPJGS28X7 | N/A
+Listing Sync Pro \| United States Monthly | A-ZR7M2V6TCD | N/A
+Listing Sync Pro \| United States \| Yext | A-WNW446NCNS | N/A
+Listing Sync Pro \| United States \| Yext \| Monthly | A-8PHKXVRZFS | N/A
+Listing Sync Pro \| United Kingdom \| Yearly | A-WCH8K4S8LS | N/A
+Listing Sync Pro \| United Kingdom \| Monthly | A-FR72RDNMP6 | N/A
 
+ ### Website
 
- ## Vendor X
+Product | Production SKU | Demo SKU
+--------|----------------|---------
+ Express |MP-ee4ea04e553a4b1780caf7aad7be07cd:EDITION-VFNL43ZF | MP-9cc9f21f0a234a46ad78087fc09f16bc:EDITION-RC58KN73
+ Pro | MP-ee4ea04e553a4b1780caf7aad7be07cd:EDITION-VENDASTAPRO | MP-9cc9f21f0a234a46ad78087fc09f16bc:EDITION-VENDASTAPRO
+
+### Customer Voice
+
+Product | Production SKU | Demo SKU
+--------|----------------|---------
+ Express |MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS | MP-fba21121b71148c9bb33e11fcd92d520:EDITION-4WWZC3RJ
+ Pro | MP-c4974d390a044c28aec31e421aa662b2:EDITION-VENDASTAPRO | MP-fba21121b71148c9bb33e11fcd92d520:EDITION-VENDASTAPRO
+
+### Advertising Intelligence
+
+Product | Production SKU | Demo SKU
+--------|----------------|---------
+ Express |MP-94072e44d5364872b672d7ab4fc7a7e8 | MP-94072e44d5364872b672d7ab4fc7a7e8
+
+Addon | Production SKU | Demo SKU
+--------|----------------|---------
+Advanced Reporting | A-3QKQHBS3R6 | A-K73WLF2QL6
+
+ ## Third Party Marketplace Products
+
+The parent product must be already active, or be included in the same order as any of its addons.
+
+Third party products are not activatable on the Demo environment.
+
+Note that Products with Order Forms are not able to be activated via API at this time, and thus are not included in this list. Please Contact support@vendasta.com if there is a Product that you are looking to activate that is not on this list.
+ 
+Product | Addon | sku
+--------|-------|---------
+Google Ads Robot |  | MP-B77R7GG4QHGKF5RMVSLVZPD3D5JSTZ4K
+|  | Google Ads: Monthly Additional Spend | A-SBGZJLT6VD
+|  | Google Ads: Additional Spend | A-6MH2JNJKV7
+|  | Google Ads: Additional Spend (Large) | A-VGMZ4L2XRF
+|  | Google Ads: Monthly Additional Spend (Large) | A-KLJSQ33CGV
+|  | White Label | A-KFDWPC5XHZ
+Online Appointment Booking |  | MP-0dc18874c6ce47ed96822e08934ba3d9
+Form Builder |  | MP-82bc9cad4ce441ef84bc1d7865a9939f
+geo.Ad from Chalk Digital |  | MP-MLXNLFH72ZZKHTLDKQ784PCZPJPTPV63
+|  | ChalkCredits- One Time | MP-MLXNLFH72ZZKHTLDKQ784PCZPJPTPV63
+|  | ChalkCredits - Monthly | MP-MLXNLFH72ZZKHTLDKQ784PCZPJPTPV63
+|  | ChalkCredits - Monthly (Higher spend) | MP-MLXNLFH72ZZKHTLDKQ784PCZPJPTPV63
+Data-Dynamix Email Marketing |  | MP-2da7414a9f604f518d6ae0127080f9e2
+Mobile Marketing & Communications Platform \| Business Texting Dashboard |  | MP-W74STW72G4WVKL52LT45NFJC3XH7M5J2
+Mobile Marketing & Communications Platform \| PLUS |  | MP-W74STW72G4WVKL52LT45NFJC3XH7M5J2:EDITION-H3HV6RMH
+Mobile Marketing & Communications Platform \| ADVANCED |  | MP-W74STW72G4WVKL52LT45NFJC3XH7M5J2:EDITION-VK8BNJ84
+Mobile Marketing & Communications Platform \| PRO |  | MP-W74STW72G4WVKL52LT45NFJC3XH7M5J2:EDITION-4GP72F25
+|  | 1,000 Message Credits | A-TXBH4JDMRD
+|  | 10,000 Message Credits | A-5ZTN8JGJTN
+|  | 2,500 Message Credits | A-DQNTF4XT4R
+|  | 25,000 Message Credits | A-XWMRP7LXPL
+|  | 5,000 Message Credits | A-CQFNHBHHL4
+|  | Digital Kiosk Stand (incl. shipping costs) | A-BGNMVFWGLH
+Metricool |  | MP-3QXRWPFX4BTVGZ3NBPSWPS8L3S7QS66W
+Pagevamp - Instant Website Builder |  | MP-16d5e227e7b647afaf233595b21bef7a
+|  | Pagevamp Website | A-CXZDQ5SQGB
+|  | Pagevamp Website Domain | A-5WVMNDWPLS
+|  | Unbranded Website | A-MHVQSWJHQ3
+Instant Website with Facebook Sync |  | MP-Q7RN4J6FDT2FNLPH6K52SRMCX5QMFS3R
+|  | Domain | A-3M3PT2HPB5
+|  | Website | A-GKVTPH8FZG
+POWr Website Plugins |  | MP-RC8VV8K5DV368F6WJ3ZCSKWG2Q62QSDC
+Social Status \| Starter |  | MP-NFWJLTZ2CN55VMRNMHQ46PNSG66M287J:EDITION-WHNMFHKG
+Social Status \| Pro |  | MP-NFWJLTZ2CN55VMRNMHQ46PNSG66M287J:EDITION-64QW5D6W
+Social Status \| Business |  | MP-NFWJLTZ2CN55VMRNMHQ46PNSG66M287J:EDITION-HDJBV62Q
+Social Status \| Company |  | MP-NFWJLTZ2CN55VMRNMHQ46PNSG66M287J:EDITION-HRVWMC5H
+Social Status \| Enterprise |  | MP-NFWJLTZ2CN55VMRNMHQ46PNSG66M287J:EDITION-4FSP4PQK
+|  | Report Credits | A-6FH4KGDFM4
+Visual Visitor |  | MP-ec5edcffc9b74d1b88a1180485d442d5

--- a/docs/Guides/Sell/FindSKU.md
+++ b/docs/Guides/Sell/FindSKU.md
@@ -1,0 +1,17 @@
+# Find a SKU
+
+We currently only support creating orders for products that don't include order forms. An API to list the SKUs from your store will be comming. In the mean time please use this list or reachout if you can't find a product you are looking for.
+
+The SKU is typically different between the demo and production environments so be sure to use the correct values.
+
+## Vendasta's Products
+
+Product | Production SKU | Demo SKU
+--------|----------------|---------
+ Customer Voice \| Standard | B1 | C1
+ Customer Voice \| Pro | B2 | C2
+ Listing Builder | B3 | C3
+ Social Marketing | a| c |
+ Reputation Management | a| c |
+ Website \| Pro | a|  c |
+ Advertising Inteligence | a | c |

--- a/docs/Guides/Sell/FindSKU.md
+++ b/docs/Guides/Sell/FindSKU.md
@@ -5,19 +5,55 @@ We currently only support creating orders for products that don't include order 
 The SKU is typically different between the demo and production environments so be sure to use the correct values.
 
 ## Your Packages
-Package SKUs start with `SOL-`. You can get them from the URL when browsing to ... screenshot
+You can use packages that you have built in your store so long as none of the products require order forms. If products are added or removed from the package at a later date future orders will reflect the change.
+
+Currently the best way to get the SKU for a package is to go to Partner Center -> Marketplace -> Manage Store -> and select your package. The page URL will contain the SKU for the package.
+
+Package SKUs start with `SOL-`. Example: `SOL-b4ee54bd-ea26-4047-b3e7-4ba075b6d1d3`
+
+## Your Private Products
+> TODO Where can partners get the edition id from?
 
 ## Vendasta's Products
 
 Product | Production SKU | Demo SKU
 --------|----------------|---------
- Customer Voice \| Standard | MP-123:EDITION-234 | C1
- Customer Voice \| Pro | B2 | C2
- Listing Builder | B3 | C3
- Social Marketing | a| c |
- Reputation Management | a| c |
- Website \| Pro | a|  c |
- Advertising Inteligence | a | c |
+ Customer Voice \| Express | MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS | TODO:TODO
+ Customer Voice \| Pro | MP-c4974d390a044c28aec31e421aa662b2:EDITION-VENDASTAPRO | TODO:TODO
+ Listing Builder | MS | MS
+ Listing Distribution | A-GMXXNQ4ZGD | TODO
+ Listing Sync Pro \| Australia | A-XQL2HMD6VV | TODO 
+ Social Marketing | TODO:TODO | TODO:TODO 
+ Reputation Management | TODO:TODO | TODO:TODO 
+ Website \| Pro | TODO:TODO | TODO:TODO 
+ Advertising Inteligence | TODO:TODO | TODO:TODO 
+ Others...|TODO|TODO
+
+
+
+> or
+
+
+## Vendasta
+
+### Customer Voice
+Product | Production SKU | Demo SKU
+--------|----------------|---------
+ Express |MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS | TODO:TODO
+ Pro | MP-c4974d390a044c28aec31e421aa662b2:EDITION-VENDASTAPRO | TODO:TODO
+
+ ### Listing Builder
+
+Product | Production SKU | Demo SKU
+--------|----------------|---------
+ Listing Builder | MS | MS
+
+ The base Listing Builder product must be already active or included in the same order as any of the addons.
+
+Addon | Production SKU | Demo SKU
+--------|----------------|---------
+ Listing Distribution | A-GMXXNQ4ZGD | TODO
+ Listing Sync Pro \| Australia | A-XQL2HMD6VV | TODO 
 
 
  ## Vendor X

--- a/docs/Guides/Sell/FindSKU.md
+++ b/docs/Guides/Sell/FindSKU.md
@@ -4,13 +4,6 @@ We currently only support creating orders for products that don't include order 
 
 The SKU is typically different between the demo and production environments so be sure to use the correct values.
 
-## Your Packages
-You can use packages that you have built in your store so long as none of the products require order forms. If products are added or removed from the package at a later date future orders will reflect the change.
-
-Currently the best way to get the SKU for a package is to go to **Partner Center -> Marketplace -> Manage Store** and select your package. The page URL will contain the SKU for the package.
-
-Package SKUs start with `SOL-`. Example: `SOL-b4ee54bd-ea26-4047-b3e7-4ba075b6d1d3`
-
 ## Your Private Products
 If your product has editions please contact support to get the SKUs for each editions. Otherwise you can get them by navigating to the product or addon in Vendor Center and looking at the URL.
 

--- a/docs/Guides/Sell/FindSKU.md
+++ b/docs/Guides/Sell/FindSKU.md
@@ -25,14 +25,14 @@ Addon SKUs start with `A-`. Example: `A-GMXXNQ4ZGD`
 Product | Production SKU | Demo SKU
 --------|----------------|---------
  Express |RM:EDITION-F7JZ5TV8 | RM:EDITION-38SMW45H
- Pro | RM:EDITION-VENDASTAPRO | RM:EDITION-VENDASTAPRO
+ Pro | RM | RM
 
 ### Social Marketing
 
 Product | Production SKU | Demo SKU
 --------|----------------|---------
  Express |SM:EDITION-FVGBNLVZ | SM:EDITION-SWVF3WH8
- Pro | SM:EDITION-VENDASTAPRO | SM:EDITION-VENDASTAPRO
+ Pro | SM | SM
 
 ### Listing Builder
 
@@ -58,9 +58,9 @@ Listing Sync Pro \| Germany Yearly | A-W2GGC7TJW3 | N/A
 Listing Sync Pro \| Germany Monthly | A-JZGCTTMHLG | N/A
 Listing Sync Pro \| Italy Yearly | A-KK3MNLFDP5 | N/A
 Listing Sync Pro \| Italy Monthly | A-CDFBK8XW2W | N/A
-Listing Sync Pro United States Yearly | A-TMPJGS28X7 | N/A
-Listing Sync Pro \| United States Monthly | A-ZR7M2V6TCD | N/A
-Listing Sync Pro \| United States \| Yext | A-WNW446NCNS | N/A
+Listing Sync Pro \| United States \| Yearly | A-TMPJGS28X7 | N/A
+Listing Sync Pro \| United States \| Monthly | A-ZR7M2V6TCD | N/A
+Listing Sync Pro \| United States \| Yext \| Yearly | A-WNW446NCNS | N/A
 Listing Sync Pro \| United States \| Yext \| Monthly | A-8PHKXVRZFS | N/A
 Listing Sync Pro \| United Kingdom \| Yearly | A-WCH8K4S8LS | N/A
 Listing Sync Pro \| United Kingdom \| Monthly | A-FR72RDNMP6 | N/A
@@ -70,14 +70,14 @@ Listing Sync Pro \| United Kingdom \| Monthly | A-FR72RDNMP6 | N/A
 Product | Production SKU | Demo SKU
 --------|----------------|---------
  Express |MP-ee4ea04e553a4b1780caf7aad7be07cd:EDITION-VFNL43ZF | MP-9cc9f21f0a234a46ad78087fc09f16bc:EDITION-RC58KN73
- Pro | MP-ee4ea04e553a4b1780caf7aad7be07cd:EDITION-VENDASTAPRO | MP-9cc9f21f0a234a46ad78087fc09f16bc:EDITION-VENDASTAPRO
+ Pro | MP-ee4ea04e553a4b1780caf7aad7be07cd | MP-9cc9f21f0a234a46ad78087fc09f16bc
 
 ### Customer Voice
 
 Product | Production SKU | Demo SKU
 --------|----------------|---------
  Express |MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS | MP-fba21121b71148c9bb33e11fcd92d520:EDITION-4WWZC3RJ
- Pro | MP-c4974d390a044c28aec31e421aa662b2:EDITION-VENDASTAPRO | MP-fba21121b71148c9bb33e11fcd92d520:EDITION-VENDASTAPRO
+ Pro | MP-c4974d390a044c28aec31e421aa662b2 | MP-fba21121b71148c9bb33e11fcd92d520
 
 ### Advertising Intelligence
 
@@ -97,7 +97,7 @@ Third party products are not activatable on the Demo environment.
 
 Note that Products with Order Forms are not able to be activated via API at this time, and thus are not included in this list. Please Contact support@vendasta.com if there is a Product that you are looking to activate that is not on this list.
  
-Product | Addon | sku
+Product | Addon | Production SKU
 --------|-------|---------
 Google Ads Robot |  | MP-B77R7GG4QHGKF5RMVSLVZPD3D5JSTZ4K
 |  | Google Ads: Monthly Additional Spend | A-SBGZJLT6VD

--- a/docs/Guides/Sell/FindSKU.md
+++ b/docs/Guides/Sell/FindSKU.md
@@ -4,14 +4,20 @@ We currently only support creating orders for products that don't include order 
 
 The SKU is typically different between the demo and production environments so be sure to use the correct values.
 
+## Your Packages
+Package SKUs start with `SOL-`. You can get them from the URL when browsing to ... screenshot
+
 ## Vendasta's Products
 
 Product | Production SKU | Demo SKU
 --------|----------------|---------
- Customer Voice \| Standard | B1 | C1
+ Customer Voice \| Standard | MP-123:EDITION-234 | C1
  Customer Voice \| Pro | B2 | C2
  Listing Builder | B3 | C3
  Social Marketing | a| c |
  Reputation Management | a| c |
  Website \| Pro | a|  c |
  Advertising Inteligence | a | c |
+
+
+ ## Vendor X

--- a/docs/Guides/Sell/FindSKU.md
+++ b/docs/Guides/Sell/FindSKU.md
@@ -1,28 +1,34 @@
 # Find a SKU
 
-We currently only support creating orders for products that don't include order forms. An API to list the SKUs from your store will be comming. In the mean time please use this list or reachout if you can't find a product you are looking for.
+We currently only support creating orders for products that don't include order forms. An API to list the SKUs from your store will be comming. In the mean time please use this list or reachout to support if you can't find a product you are looking for.
 
 The SKU is typically different between the demo and production environments so be sure to use the correct values.
 
 ## Your Packages
 You can use packages that you have built in your store so long as none of the products require order forms. If products are added or removed from the package at a later date future orders will reflect the change.
 
-Currently the best way to get the SKU for a package is to go to Partner Center -> Marketplace -> Manage Store -> and select your package. The page URL will contain the SKU for the package.
+Currently the best way to get the SKU for a package is to go to **Partner Center -> Marketplace -> Manage Store** and select your package. The page URL will contain the SKU for the package.
 
 Package SKUs start with `SOL-`. Example: `SOL-b4ee54bd-ea26-4047-b3e7-4ba075b6d1d3`
 
 ## Your Private Products
-> TODO Where can partners get the edition id from?
+If your product has editions please contact support to get the SKUs for each editions. Otherwise you can get them by navigating to the product or addon in Vendor Center and looking at the URL.
+
+Product SKUs start with `MP-`. Example: `MP-c4974d390a044c28aec31e421aa662b2`
+
+Addon SKUs start with `A-`. Example: `A-GMXXNQ4ZGD`
+
+
 
 ## Vendasta's Products
 
 Product | Production SKU | Demo SKU
 --------|----------------|---------
- Customer Voice \| Express | MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS | TODO:TODO
- Customer Voice \| Pro | MP-c4974d390a044c28aec31e421aa662b2:EDITION-VENDASTAPRO | TODO:TODO
+ Customer Voice \| Express | MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS | MP-fba21121b71148c9bb33e11fcd92d520:EDITION-4WWZC3RJ
+ Customer Voice \| Pro | MP-c4974d390a044c28aec31e421aa662b2:EDITION-VENDASTAPRO | MP-fba21121b71148c9bb33e11fcd92d520:EDITION-VENDASTAPRO
  Listing Builder | MS | MS
- Listing Distribution | A-GMXXNQ4ZGD | TODO
- Listing Sync Pro \| Australia | A-XQL2HMD6VV | TODO 
+ Listing Distribution | A-GMXXNQ4ZGD | A-FR5P5ND7KN
+ Listing Sync Pro \| Australia | A-XQL2HMD6VV | A-WQF6NBH4LB 
  Social Marketing | TODO:TODO | TODO:TODO 
  Reputation Management | TODO:TODO | TODO:TODO 
  Website \| Pro | TODO:TODO | TODO:TODO 

--- a/docs/Guides/Sell/Overview.md
+++ b/docs/Guides/Sell/Overview.md
@@ -154,6 +154,8 @@ will add the number of units specified by the `quantity` attribute to any existi
 
 
 ### Apply default pricing to the order items
+**Coming soon**
+
 If product has been configured with a Retail Price at Partner Center -> Marketplace -> Manage Products -> Product Settings, you may leave off the `amount` and `intervalCode` to have the configured price be used.
 
 ### Sell a product with an order form

--- a/docs/Guides/Sell/Overview.md
+++ b/docs/Guides/Sell/Overview.md
@@ -1,6 +1,6 @@
 # Sell your products
 
-Products and packages that you have added to your store can be sold to a business location by creating an order.
+Products that you have added to your store can be sold to a business location by creating an order.
 
 You simply need the product SKU ([found here](FindSKU.md)), ID of a previously created business location, and the price you will be charging to your customer. 
 

--- a/docs/Guides/Sell/Overview.md
+++ b/docs/Guides/Sell/Overview.md
@@ -7,7 +7,7 @@ You simply need the product SKU ([found here](FindSKU.md)), ID of a previously c
 ## Examples
 
 ### Sell a simple product (without an order form)
-The following request will activate Customer Voice | Express (MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS) for business location AG-1234567. If automatic invoicing is turned on an invoice in the amount of $18.00 CAD will be created.
+The following request will activate the Express edition of Customer Voice (MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS) for business location AG-1234567. If automatic invoicing is turned on an invoice in the amount of $18.00 AUD will be created.
 ```json http
 {
   "method": "post",
@@ -93,23 +93,68 @@ You may use the `ID` that was returned when creating an order to check the statu
 ```
 
 
-> TODO Should we break out each "advanced" example to its own page or just the last two? It would let us get page view metrics for the features that are coming soon. 
-
 ### Change editions of a simple product
 Simply create a new order with the SKU for the desired product edition. The prior activation, if any, will automatically be cancelled when the new edition activates. 
 
 ### Sell multiple products at once
+You may include multiple products in a single order by adding additional line items. The order status will not switch to `fulfilled` until all products have been activated.
+
+This example will activate Customer Voice at a monthly cost of $16.50 AUD, Listing Builder at a montly cost of $27.97 AUD, and Listing Distribution at a yearly cost of $350.97
+```json http
+{
+  "method": "post",
+  "url": "https://prod.apigateway.co/platform/orders",
+  "query": {},
+  "headers": {
+    "Authorization": "Bearer <Token with 'order' scope>",
+    "Content-Type": "application/vnd.api+json"
+  },
+  "body": {
+  "data": {
+    "type": "orders",
+    "attributes": {
+      "currencyCode": "AUD",
+      "lineItems": [
+        {
+          "sku": "MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS",
+          "quantity": 1,
+          "amount": 1650,
+          "intervalCode": "monthly"
+        },
+        {
+          "sku": "MS",
+          "quantity": 1,
+          "amount": 2797,
+          "intervalCode": "monthly"
+        },
+        {
+          "sku": "A-GMXXNQ4ZGD",
+          "quantity": 1,
+          "amount": 35097,
+          "intervalCode": "yearly"
+        }
+      ]
+    },
+    "relationships": {
+      "businessLocation": {
+        "data": {
+          "id": "AG-1234567",
+          "type": "businessLocations"
+        }
+      }
+    }
+  }
+}
+}
+```
 
 ### Sell multiple units of a product
+For products that can have multiple units purchased creating a new order
+will add the number of units specified by the `quantity` attribute to any existing subscriptions. The per unit `amount` will only apply to the new units. 
 
-### Sell a product with an order form
-Coming soon
 
 ### Apply default pricing to the order items
 If product has been configured with a Retail Price at Partner Center -> Marketplace -> Manage Products -> Product Settings, you may leave off the `amount` and `intervalCode` to have the configured price be used.
 
-### Activate the Online Toolkit
-Full example including creating an account group
-
-### Activate Reputation Managment
-Full example including creating an account group with the fields Rep Man uses
+### Sell a product with an order form
+Coming soon

--- a/docs/Guides/Sell/Overview.md
+++ b/docs/Guides/Sell/Overview.md
@@ -7,8 +7,91 @@ You simply need the product SKU ([found here](FindSKU.md)), ID of a previously c
 ## Examples
 
 ### Sell a simple product (without an order form)
+The following request will activate Customer Voice | Express (MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS) for business location AG-1234567. If automatic invoicing is turned on an invoice in the amount of $18.00 CAD will be created.
+```json http
+{
+  "method": "post",
+  "url": "https://prod.apigateway.co/platform/orders",
+  "query": {},
+  "headers": {
+    "Authorization": "Bearer <Token with 'order' scope>",
+    "Content-Type": "application/vnd.api+json"
+  },
+  "body": {
+  "data": {
+    "type": "orders",
+    "attributes": {
+      "currencyCode": "AUD",
+      "lineItems": [
+        {
+          "sku": "MP-c4974d390a044c28aec31e421aa662b2:EDITION-TC8HJZNS",
+          "quantity": 1,
+          "amount": 1800,
+          "intervalCode": "monthly"
+        }
+      ]
+    },
+    "relationships": {
+      "businessLocation": {
+        "data": {
+          "id": "AG-1234567",
+          "type": "businessLocations"
+        }
+      }
+    }
+  }
+}
+}
+```
+
+In the response from creating the order you will notice the `statusCode` immediatly goes to `processing` while the products start to be activated. 
+```json
+{
+  "data": {
+    "type": "orders",
+    "id": "AG-1234567:ORD-SJFGNNP55T",
+    "attributes": {
+      "lineItems": [
+        {
+          "sku": "MP-fba21121b71148c9bb33e11fcd92d520:EDITION-4WWZC3RJ",
+          "quantity": 1,
+          "amount": 1800,
+          "intervalCode": "monthly"
+        }
+      ],
+      "currencyCode": "AUD",
+      "statusCode": "processing"
+    },
+    "relationships": {
+      "businessLocation": {
+        "links": {
+          "related": "https://prod.apigateway.co/platform/orders/AG-1234567:ORD-SJFGNNP55T/businessLocation",
+          "self": "https://prod.apigateway.co/platform/orders/AG-1234567:ORD-SJFGNNP55T/relationships/businessLocation"
+        },
+        "data": {
+          "type": "businessLocations",
+          "id": "AG-1234567"
+        }
+      }
+    }
+  }
+}
+```
 
 ### Verify the order was processed
+
+You may use the `ID` that was returned when creating an order to check the status periodicly until it reaches a `fulfilled` or `error` status. 
+
+```json http
+{
+  "method": "get",
+  "url": "https://prod.apigateway.co/platform/orders/AG-1234567:ORD-SJFGNNP55T",
+  "headers": {
+    "Authorization": "Bearer <Token with 'order' scope>"
+  }
+}
+```
+
 
 > TODO Should we break out each "advanced" example to its own page or just the last two? It would let us get page view metrics for the features that are coming soon. 
 

--- a/docs/Guides/Sell/Overview.md
+++ b/docs/Guides/Sell/Overview.md
@@ -1,0 +1,20 @@
+# Sell your products
+
+Products and packages that you have added to your store can be sold to a business location by creating an order.
+
+You simply need the product SKU (found here), ID of a previously created business location, and price you will be charging
+
+## Examples
+
+### Sell a simple product (without an order form)
+
+### Verify the order was processed
+
+### Change editions of a simple product
+
+### Sell multiple products at once
+
+### Sell a product with an order form
+
+### Sell multiple units of a product
+

--- a/docs/Guides/Sell/Overview.md
+++ b/docs/Guides/Sell/Overview.md
@@ -2,7 +2,7 @@
 
 Products and packages that you have added to your store can be sold to a business location by creating an order.
 
-You simply need the product SKU (found here), ID of a previously created business location, and price you will be charging
+You simply need the product SKU ([found here](FindSKU.md)), ID of a previously created business location, and the price you will be charging to your customer. 
 
 ## Examples
 
@@ -10,11 +10,23 @@ You simply need the product SKU (found here), ID of a previously created busines
 
 ### Verify the order was processed
 
+> TODO Should we break out each "advanced" example to its own page or just the last two? It would let us get page view metrics for the features that are coming soon. 
+
 ### Change editions of a simple product
+Simply create a new order with the SKU for the desired product edition. The prior activation, if any, will automatically be cancelled when the new edition activates. 
 
 ### Sell multiple products at once
 
-### Sell a product with an order form
-
 ### Sell multiple units of a product
 
+### Sell a product with an order form
+Coming soon
+
+### Apply default pricing to the order items
+If product has been configured with a Retail Price at Partner Center -> Marketplace -> Manage Products -> Product Settings, you may leave off the `amount` and `intervalCode` to have the configured price be used.
+
+### Activate the Online Toolkit
+Full example including creating an account group
+
+### Activate Reputation Managment
+Full example including creating an account group with the fields Rep Man uses

--- a/toc.json
+++ b/toc.json
@@ -71,6 +71,22 @@
     },
     {
       "type": "group",
+      "title": "Sales",
+      "items": [
+        {
+          "type": "item",
+          "title": "Overview",
+          "uri": "docs/Guides/Sell/Overview.md"
+        },
+        {
+          "type": "item",
+          "title": "Find a SKU",
+          "uri": "docs/Guides/Sell/FindSKU.md"
+        }
+      ]
+    },
+    {
+      "type": "group",
       "title": "Financial",
       "items": [
         {


### PR DESCRIPTION
Adding some guides to go with the new orders endpoints. 

@ncline-va would you mind filling in the Find a SKU page from the list of products without order forms that you have before this is merged.

Within the `Sell` folder (open to other names) I would like to see full page guides to activate the Online Toolkit and other O&O products for a brand new business location. I'm going to leave them out for now. 

We may want to break some of the other examples out into their own pages as well so that we can track pageviews to each of them. Thoughts?  

You may preview the guides [here](https://vendasta.stoplight.io/docs/openapi-specs/branches/preview-orders-guides/docs/Guides/Sell/Overview.md).

EA-200
@vendasta/external-apis @jredl-va @ncline-va @AllanWolinski 