### PR TITLE
Add a reference to the assigned salesperson

### DIFF
--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -1387,6 +1387,24 @@ components:
                       example: ABC
               required:
                 - data
+            businessSalesperson:
+              type: object
+              description: A link to the salesperson assigned to this business location.
+              properties:
+                data:
+                  type: object
+                  required:
+                    - type
+                    - id
+                  properties:
+                    type:
+                      type: string
+                      default: users
+                      enum:
+                        - users
+                    id:
+                      type: string
+                      example: U-20201842-235f-4b18-84ed-5b9ca4857bb3
             businessCategories:
               type: object
               description: A list of the types of business this location should be compared against. If not set during creation it will default "other".


### PR DESCRIPTION
Hey @richard-rance , here is what I was thinking of adding to the BusinessLocation API to allow one to figure out the assigned salesperson. 