### PR TITLE
Rename security schema

### DIFF
--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -50,7 +50,7 @@ paths:
 
         Note: Currently when creating a contact you must specify exactly 1 Business Location id for it to be linked to. We intend to expand this limit.
       security:
-        - OAuth:
+        - OAuth2:
             - sales.contact
       requestBody:
         content:
@@ -86,7 +86,7 @@ paths:
         - Options
         - Sales Contacts
       summary: List valid HTTP verbs for /salesContacts
-      description: "Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user's security. You should not call this operation directly. "
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
           description: No Content
@@ -119,7 +119,7 @@ paths:
                         type: string
       operationId: get-salesContacts-id
       security:
-        - OAuth:
+        - OAuth2:
             - sales.contact
       x-lifecycle:
         status: trustedTester
@@ -139,7 +139,7 @@ paths:
     options:
       operationId: options-salesContacts-id
       summary: 'List valid HTTP verbs for /salesContacts/{id}'
-      description: "Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user's security. You should not call this operation directly. "
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
           description: No Content
@@ -212,14 +212,14 @@ paths:
           required: true
           description: Indicates the format of the request body being sent. In most cases you will want `application/vnd.api+json`
       security:
-        - OAuth:
+        - OAuth2:
             - business
       tags:
         - Business Locations
     options:
       operationId: options-businessLocations
       summary: List valid HTTP verbs for /businessLocations
-      description: "Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user's security. You should not call this operation directly. "
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
           description: No Content
@@ -283,7 +283,7 @@ paths:
           description: The maximum number of tasks you would like returned in a single batch. Use the links.next member in the response to get the remainder.
           name: 'page[limit]'
       security:
-        - OAuth:
+        - OAuth2:
             - business
       tags:
         - Business Locations
@@ -332,12 +332,12 @@ paths:
           description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
           required: true
       security:
-        - OAuth:
+        - OAuth2:
             - business
     options:
       operationId: options-businessLocations-id
       summary: 'List valid HTTP verbs for /businessLocations/{id}'
-      description: "Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user's security. You should not call this operation directly. "
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
           description: No Content
@@ -375,7 +375,7 @@ paths:
           required: true
           description: Indicates the format of the request body being sent. In most cases you will want `application/vnd.api+json`
       security:
-        - OAuth:
+        - OAuth2:
             - business
       responses:
         '200':
@@ -467,14 +467,14 @@ paths:
           required: true
           description: Indicates the format of the request body being sent. In most cases you will want `application/vnd.api+json`
       security:
-        - OAuth:
+        - OAuth2:
             - user.admin
       tags:
         - Users
     options:
       operationId: options-users
       summary: List valid HTTP verbs for /users
-      description: "Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user's security. You should not call this operation directly. "
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
           description: No Content
@@ -569,7 +569,7 @@ paths:
           name: 'filter[category]'
           description: 'Filter the users based on the broad category that they fall into. In some rare cases users may be part of multiple categories. '
       security:
-        - OAuth:
+        - OAuth2:
             - user.admin
             - user.list
       tags:
@@ -619,7 +619,7 @@ paths:
           description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
           required: true
       security:
-        - OAuth:
+        - OAuth2:
             - user.admin
             - 'user.profile:read'
             - 'user.contact:read'
@@ -635,7 +635,7 @@ paths:
     options:
       operationId: options-users-id
       summary: 'List valid HTTP verbs for /users/{id}'
-      description: "Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user's security. You should not call this operation directly. "
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
           description: No Content
@@ -673,7 +673,7 @@ paths:
           required: true
           description: Indicates the format of the request body being sent. In most cases you will want `application/vnd.api+json`
       security:
-        - OAuth:
+        - OAuth2:
             - user.admin
       responses:
         '200':
@@ -712,7 +712,7 @@ paths:
 
         Deleting a user will remove personal data from it and prevent the ID from being used again in the future.
       security:
-        - OAuth:
+        - OAuth2:
             - user.admin
       tags:
         - Users
@@ -732,7 +732,7 @@ paths:
         - Purchases
       operationId: get-purchases
       security:
-        - OAuth:
+        - OAuth2:
             - financial
       x-lifecycle:
         status: trustedTester
@@ -809,7 +809,7 @@ paths:
     options:
       operationId: options-purchases
       summary: List valid HTTP verbs for /purchases
-      description: "Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user's security. You should not call this operation directly. "
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
           description: No Content
@@ -823,7 +823,7 @@ paths:
       tags:
         - Business Categories
       security:
-        - OAuth:
+        - OAuth2:
             - business
       x-lifecycle:
         status: trustedTester
@@ -886,7 +886,7 @@ paths:
     options:
       operationId: options-businessCategories
       summary: List valid HTTP verbs for /businessCategories
-      description: "Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user's security. You should not call this operation directly. "
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
           description: No Content
@@ -956,12 +956,12 @@ paths:
           required: true
           description: Indicates the format of the request body being sent. In most cases you will want `application/vnd.api+json`
       security:
-        - OAuth:
+        - OAuth2:
             - order
     options:
       operationId: options-orders
       summary: 'List valid HTTP verbs for /orders/{id}'
-      description: "Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user's security. You should not call this operation directly. "
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
           description: No Content
@@ -1002,7 +1002,7 @@ paths:
 
         Produces a list of orders.
       security:
-        - OAuth:
+        - OAuth2:
             - order
       parameters:
         - schema:
@@ -1060,7 +1060,7 @@ paths:
                         type: string
       operationId: get-orders-id
       security:
-        - OAuth:
+        - OAuth2:
             - order
       x-lifecycle:
         status: trustedTester
@@ -1080,7 +1080,7 @@ paths:
     options:
       operationId: options-order-id
       summary: 'List valid HTTP verbs for /orders/{id}'
-      description: "Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user's security. You should not call this operation directly. "
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
           description: No Content
@@ -1151,7 +1151,7 @@ paths:
           required: true
           description: Indicates the format of the request body being sent. In most cases you will want `application/vnd.api+json`
       security:
-        - OAuth:
+        - OAuth2:
             - user.admin
       tags:
         - Users
@@ -1166,7 +1166,7 @@ paths:
           description: Accepted
       operationId: post-autoamtionruns
       security:
-        - OAuth:
+        - OAuth2:
             - business
       x-lifecycle:
         status: trustedTester
@@ -1201,7 +1201,7 @@ paths:
     options:
       operationId: options-automationruns-id
       summary: List valid HTTP verbs for /automationRuns
-      description: "Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user's security. You should not call this operation directly. "
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
           description: No Content
@@ -1214,7 +1214,7 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-    OAuth:
+    OAuth2:
       type: oauth2
       flows:
         authorizationCode:
@@ -1231,7 +1231,7 @@ components:
             'user.permission:read': 'Read access to the permission info (accessible locations, features and roles) of all categories of users'
             user.permission: 'Read-write access to the permission info (accessible locations, features and roles) of all categories of users'
             user.admin: Read-write access to manage all users
-            user.list: "'Allows searching for users based on a set of filters. (ex: email, name, category, organization). Without this scope an exact user id is required."
+            user.list: '''Allows searching for users based on a set of filters. (ex: email, name, category, organization). Without this scope an exact user id is required.'
             self.user.admin: 'Allows editing the profile, contact info and profile image for the current user.'
             'self.user.contact:read': 'Read access to the contact info (email, phone, address) of the current user.'
             openid: Allows getting the user id of the current user
@@ -1877,7 +1877,7 @@ components:
             emailVerified:
               type: boolean
               default: false
-              description: "True if the End-User's e-mail address has been verified; otherwise false. When true affirmative steps to ensure that this e-mail address was controlled by the End-User at the time the verification was performed. "
+              description: 'True if the End-User''s e-mail address has been verified; otherwise false. When true affirmative steps to ensure that this e-mail address was controlled by the End-User at the time the verification was performed. '
               readOnly: true
             emailSet:
               type: boolean

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -2121,11 +2121,15 @@ components:
 
         An Automation run is the instance of an automation executing its steps for a business location.
         You may configure the automation definition and obtain its ID within Partner Center.
+      x-tags:
+        - Automation Runs
       properties:
         type:
           type: string
           default: automationRuns
           example: automationRuns
+          enum:
+            - automationRuns
           readOnly: true
         relationships:
           type: object
@@ -2175,8 +2179,6 @@ components:
                       pattern: ^Automation-
       required:
         - relationships
-      x-tags:
-        - Automation Runs
 tags:
   - name: Automation Runs
   - name: Business Categories


### PR DESCRIPTION
Change the display name of the security schema from `OAuth` to `OAuth2` for clarity. Potentially we should rename it `OAuth2 - Demo` and duplicate it for prod. 

@vendasta/external-apis 