### PR TITLE
AD-666 Move Guide Location

### DIFF
--- a/toc.json
+++ b/toc.json
@@ -147,10 +147,6 @@
       ]
     },
     {
-      "type":"divider",
-      "title": "Platform"
-    },
-    {
       "type": "group",
       "title": "Advertising Intelligence",
       "items": [
@@ -160,6 +156,10 @@
           "uri": "docs/Guides/Advertising/accountStats.md"
         }
       ]
+    },
+    {
+      "type":"divider",
+      "title": "Platform"
     },
     {
       "type": "item",


### PR DESCRIPTION
I accidentally put the Advertising Intelligence Guide under the Platform API divider instead of the guides section.

This PR moves it to the right place

@vendasta/adlads 
@richard-rance 