### PR TITLE
AD-666 Remove extra tags for options requests

### DIFF
--- a/openapi/adintel/adintel.yaml
+++ b/openapi/adintel/adintel.yaml
@@ -73,7 +73,6 @@ paths:
           description: OK
       description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       tags:
-        - accountStats
         - options
   '/accountStats/{connectedAccount.id}':
     parameters:
@@ -131,7 +130,6 @@ paths:
           description: OK
       description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       tags:
-        - accountStats
         - options
 components:
   schemas:


### PR DESCRIPTION
The options requests weren't appearing in the correct spot in the docs, so I decided to remove the accountStats tags so that the options tags would apply
