### PR TITLE
[SOC-2047] Add Social pages to TOC.

### DIFF
--- a/toc.json
+++ b/toc.json
@@ -174,6 +174,11 @@
       "type": "item",
       "title": "Ad Intel APIs",
       "uri": "openapi/adintel/adintel.yaml"
+    },
+    {
+      "type": "item",
+      "title": "Social Marketing APIs",
+      "uri": "openapi/social/social.yaml"
     }
   ]
 }


### PR DESCRIPTION
## [SOC-2047] Add Social pages to TOC.

Adds the social folder to the `products` branch of our documentation.

@richard-rance @Short-Hop @ndougherty-va @wfehr-va @DewaldoDev

[SOC-2047]: https://vendasta.jira.com/browse/SOC-2047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ