### PR TITLE
AD-670 Set Advertising endpoints to Trusted Tester

### DIFF
--- a/openapi/advertising/advertising.yaml
+++ b/openapi/advertising/advertising.yaml
@@ -186,7 +186,7 @@ paths:
         - OAuth2:
             - advertising
       x-lifecycle:
-        status: proposed
+        status: trustedTester
       tags:
         - Connected Accounts
   /connectedAccounts:
@@ -227,7 +227,7 @@ paths:
                   - links
       description: Retrieve all connected advertising accounts.
       x-lifecycle:
-        status: proposed
+        status: trustedTester
       security:
         - OAuth2:
             - advertising
@@ -293,7 +293,7 @@ paths:
         - OAuth2:
             - advertising
       x-lifecycle:
-        status: proposed
+        status: trustedTester
     options:
       summary: ''
       operationId: options-campaignInfo
@@ -347,7 +347,7 @@ paths:
         - $ref: '#/components/parameters/Authorization'
         - $ref: '#/components/parameters/Content-Type'
       x-lifecycle:
-        status: proposed
+        status: trustedTester
     options:
       summary: ''
       operationId: options-campaignInfo-id
@@ -398,7 +398,7 @@ paths:
         - $ref: '#/components/parameters/pageLimit'
         - $ref: '#/components/parameters/pageCursor'
       x-lifecycle:
-        status: proposed
+        status: trustedTester
     options:
       summary: ''
       operationId: options-campaignStats
@@ -460,6 +460,8 @@ paths:
         - $ref: '#/components/parameters/Content-Type'
         - $ref: '#/components/parameters/startAt'
         - $ref: '#/components/parameters/endAt'
+      x-lifecycle:
+        status: trustedTester
     options:
       summary: ''
       operationId: options-campaignStats-id
@@ -477,6 +479,7 @@ components:
       x-examples: {}
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+
         Total Stats for a connected Advertising Account
       properties:
         id:
@@ -532,10 +535,11 @@ components:
       type: object
       x-examples: {}
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+
         Total Stats for a connected Advertising Campaign
       x-lifecycle:
-        status: proposed
+        status: trustedTester
       x-tags:
         - Campaign Stats
       properties:
@@ -579,10 +583,13 @@ components:
     connectedAccounts:
       title: connectedAccounts
       type: object
-      description: 'An advertising account that’s connected within Advertising Intelligence from integrated campaign management platforms, including Google Adwords, Facebook Ads and Local Ads.'
+      description: |-
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+
+        An advertising account that’s connected within Advertising Intelligence from integrated campaign management platforms, including Google Adwords, Facebook Ads and Local Ads.
       x-examples: {}
       x-lifecycle:
-        status: proposed
+        status: trustedTester
       x-tags:
         - Connected Accounts
       properties:
@@ -628,14 +635,15 @@ components:
         - type
         - attributes
     campaignInfo:
-      title: campaignInfo
+      title: Campaign Info
       type: object
       x-examples: {}
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+
         Information about an advertising campaign.  Requires an Advanced Reporting Addon to be active on the Business Location to access
       x-lifecycle:
-        status: proposed
+        status: trustedTester
       properties:
         id:
           type: string


### PR DESCRIPTION
Sets all the advertising endpoints lifecycles to trusted tester.

@vendasta/adlads 