### PR TITLE
Custom Fields: Long names are not being displayed (AG-1371)

### DIFF
--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -3449,7 +3449,7 @@ components:
 
                           TestSalesAccountCustomFields_update/platform/users?filter[partner.id]=TEST&filter[email]=user@example.com`.
 
-                          For more information access [GET /platform/users](platform/branches/np-ag-1371-reform-sales-account/b3A6MTMxNTA2NDE-get-user)
+                          For more information access [GET /platform/users](b3A6MTMxNTA2NDE-get-user)
                       type:
                         type: string
                         example: users

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -1944,7 +1944,7 @@ paths:
         in: path
         required: true
     get:
-      summary: Get Sales Account Custom Fields ID
+      summary: Get Custom Fields ID
       responses:
         '200':
           description: OK
@@ -1991,7 +1991,7 @@ paths:
       x-lifecycle:
         status: proposed
       tags:
-        - Sales Account Custom Fields
+        - Sales Accounts
       parameters:
         - schema:
             type: string
@@ -2010,7 +2010,7 @@ paths:
       description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       tags:
         - Options
-        - Sales Account Custom Fields
+        - Sales Accounts
   '/salesAccounts/{id}/customFields':
     parameters:
       - schema:
@@ -2019,7 +2019,7 @@ paths:
         in: path
         required: true
     get:
-      summary: Get Sales Account Custom Fields by Sales Account
+      summary: Get Custom Fields
       responses:
         '200':
           description: OK
@@ -2078,7 +2078,7 @@ paths:
       x-lifecycle:
         status: trustedTester
       tags:
-        - Sales Account Custom Fields
+        - Sales Accounts
       parameters:
         - schema:
             type: string
@@ -2097,7 +2097,7 @@ paths:
       description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       tags:
         - Options
-        - Sales Account Custom Fields
+        - Sales Accounts
   '/salesAccountCustomFields/{id}':
     parameters:
       - schema:
@@ -2108,7 +2108,7 @@ paths:
         example: AG-1231231
         description: The ID of the Custom Fields - actually the same id of the Sales Account
     patch:
-      summary: Update custom fields for a sales account
+      summary: Update Custom Fields
       operationId: patch-salesAccountCustomFields-by-id
       requestBody:
         content:
@@ -2197,7 +2197,7 @@ paths:
       tags:
         - Sales Account Custom Fields
     get:
-      summary: Get Sales Account Custom Fields by ID
+      summary: Get Custom Fields by ID
       responses:
         '200':
           description: OK

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -2071,7 +2071,7 @@ paths:
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
 
-        This endpoint acts like a alias to [Get Sales Account Custom Fields by ID endpoint](/platform/branches/np-ag-1371-reform-sales-account/b3A6MzYxMTM5MTY-get-sales-account-custom-data-by-id). It returns custom fields about a sales account.
+        This endpoint acts like a alias to [Get Sales Account Custom Fields by ID endpoint](b3A6MzYxMTM5MTY-get-sales-account-custom-data-by-id). It returns custom fields about a sales account.
       security:
         - OAuth2:
             - sales.account


### PR DESCRIPTION
## Problem
Documentation page is not being able to display operations with long names, and some of them end up with the same prefix
<img width="296" alt="Screen Shot 2022-01-19 at 5 06 30 PM" src="https://user-images.githubusercontent.com/73379/150235244-eca792e8-ce50-46e3-899e-ac8a1767e016.png">

## Solution
Re-organize and chose shorter names

### notes
I also add a small fix in a link, that I thought that I did in the last PR

@vendasta/np-easy 
@richard-rance 
[AG-1371](https://vendasta.jira.com/browse/AG-1371)
