### PR TITLE
LB-2347: Update terminology for listings API

### DIFF
--- a/docs/Guides/Listings/Listing.md
+++ b/docs/Guides/Listings/Listing.md
@@ -2,21 +2,21 @@
 tags: [listings]
 ---
 
-# Listing
+# (WIP do not push to master) Listing
 
-An online webpage containing an entity's location, service area, hours, and other vital business information.
+An online webpage, GPS directory, data aggregator, etc. containing a business's location, service area, hours, and other vital business information.
 
 ## Common Actions
 
-## View listings for an entity
+## View listings for an business
 
-To view the listings for a business entity make the following request filling in the business location ID and
+To view the listings for a business location make the following request filling in the business location ID and
 an [access token](../../Authorization/2-legged-oauth/UsingAServiceAccount.md)
 
 ```json http
 {
   "method": "get",
-  "url": "https://prod.apigateway.co/products/listingBuilder/listListings",
+  "url": "https://prod.apigateway.co/products/listings/listingSyncListings",
   "query": {
     "filter[businessLocations.id]": "AG-123456",
   },

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -21,7 +21,7 @@ paths:
       tags:
         - Listing Sync Listings
       summary: List Listing Sync Listings
-      operationId: list-businessListings
+      operationId: list-listingSyncListings
       security:
         - OAuth2:
             - listing
@@ -82,8 +82,8 @@ paths:
                         description: The URI at which the next batch of reviews can be gotten from
                         format: uri
     options:
-      operationId: options-businessLocationListings
-      summary: List valid HTTP verbs for /businessLocationListings
+      operationId: options-listingSyncListings
+      summary: List valid HTTP verbs for /listingSyncListings
       description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
@@ -148,7 +148,7 @@ components:
           scopes:
             listing: Access to the Listing Builder REST API
   schemas:
-    businessLocationListings:
+    listingSyncListings:
       title: Listing Sync Listings
       type: object
       x-lifecycle:

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -16,20 +16,20 @@ tags:
   - name: Business Entity Listings
   - name: Options
 paths:
-  /businessEntityListings:
+  /businessLocationListings:
     get:
       tags:
         - Business Entity Listings
-      summary: List Business Entity Listings
+      summary: List Business Location Listings
       operationId: list-businessListings
       security:
         - OAuth2:
             - listing
       x-lifecycle:
-        status: proposed
+        status: trustedTester
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
-        Gets a list of listings for a business entity
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+        Gets a list of listings for a business location
       parameters:
         - schema:
             type: string
@@ -98,9 +98,9 @@ paths:
         - Options
         - Business Entity Listings
     parameters: []
-  '/businessEntityListingScores/{id}':
+  '/businessLocationListingScores/{id}':
     get:
-      summary: Get Business Entity Listing Score
+      summary: Get Business Location Listing Score
       tags: []
       responses:
         '200':
@@ -114,10 +114,10 @@ paths:
                     $ref: '#/components/schemas/businessEntityListingScore'
       operationId: get-businessEntityListingScore
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
         Get the listing score information for a specific business
       x-lifecycle:
-        status: proposed
+        status: trustedTester
       security:
         - OAuth2:
             - listing
@@ -149,15 +149,13 @@ components:
             listing: Access to the Listing Builder REST API
   schemas:
     businessEntityListings:
-      title: Business Entity Listings
+      title: Business Location Listings
       type: object
       x-lifecycle:
-        status: proposed
+        status: trustedTester
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
-        Gets a list of listings for a business entity
-      x-tags:
-        - Business Entity Listings
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+        Gets a list of listings for a business location
       x-internal: false
       properties:
         id:
@@ -392,6 +390,8 @@ components:
 
                 notFound - No listing was found for this source by Vendasta.
               type: string
+      x-tags:
+        - Business Location Listings
     businessEntityListingScore:
       title: businessEntityListingScore
       type: object

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -26,9 +26,9 @@ paths:
         - OAuth2:
             - listing
       x-lifecycle:
-        status: trustedTester
+        status: proposed
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
         Gets a list of listings for a business location. This corresponds to the Listing Sync page in Listing Builder.
       parameters:
         - schema:
@@ -114,10 +114,10 @@ paths:
                     $ref: '#/components/schemas/listingScore'
       operationId: get-listingScore
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
         Get the listing score information for a specific business
       x-lifecycle:
-        status: trustedTester
+        status: proposed
       security:
         - OAuth2:
             - listing
@@ -152,9 +152,9 @@ components:
       title: Listing Sync Listings
       type: object
       x-lifecycle:
-        status: trustedTester
+        status: proposed
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
         A list of listings for a business location
       x-internal: false
       properties:
@@ -401,9 +401,9 @@ components:
           description: Vendasta's unique ID for the business
         type:
           type: string
-          default: listingScore
+          default: listingScores
           enum:
-            - listingScore
+            - listingScores
         attributes:
           type: object
           properties:
@@ -416,7 +416,7 @@ components:
             initialListingScore:
               type: integer
               description: The listing score of the business when Listing Builder was first activated
-      x-lifecycle: trustedTester
+      x-lifecycle: proposed
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
         The listing score information for a business location

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -13,13 +13,13 @@ servers:
   - url: 'http://localhost:11001/products/listings'
     description: Localhost
 tags:
-  - name: Business Entity Listings
+  - name: Business Location Listings
   - name: Options
 paths:
   /businessLocationListings:
     get:
       tags:
-        - Business Entity Listings
+        - Business Location Listings
       summary: List Business Location Listings
       operationId: list-businessListings
       security:
@@ -43,7 +43,7 @@ paths:
             type: string
           in: query
           name: 'filter[businessLocation.id]'
-          description: Return listings for the specified business entity
+          description: Return listings for the specified business location
           required: true
         - schema:
             type: string
@@ -66,7 +66,7 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: '#/components/schemas/businessEntityListings'
+                      $ref: '#/components/schemas/businessLocationListings'
                   links:
                     type: object
                     properties:
@@ -82,21 +82,21 @@ paths:
                         description: The URI at which the next batch of reviews can be gotten from
                         format: uri
     options:
-      operationId: options-businessEntityListings
-      summary: List valid HTTP verbs for /businessEntityListings
+      operationId: options-businessLocationListings
+      summary: List valid HTTP verbs for /businessLocationListings
       description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
       responses:
         '204':
           description: No Content
         '403':
-          description: User Cannot Access Entity
+          description: User Cannot Access Business Location
         '404':
           description: Business Not Found
         '406':
           description: No Listing Product Active
       tags:
         - Options
-        - Business Entity Listings
+        - Business Location Listings
     parameters: []
   '/businessLocationListingScores/{id}':
     get:
@@ -111,8 +111,8 @@ paths:
                 type: object
                 properties:
                   data:
-                    $ref: '#/components/schemas/businessEntityListingScore'
-      operationId: get-businessEntityListingScore
+                    $ref: '#/components/schemas/businessLocationListingScore'
+      operationId: get-businessLocationListingScore
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
         Get the listing score information for a specific business
@@ -148,7 +148,7 @@ components:
           scopes:
             listing: Access to the Listing Builder REST API
   schemas:
-    businessEntityListings:
+    businessLocationListings:
       title: Business Location Listings
       type: object
       x-lifecycle:
@@ -293,7 +293,7 @@ components:
               description: |-
                 Service area businesses will not have this field.
 
-                For a physical location this physical address of the entity. Vendasta’s platform supports multiple address lines but currently those are combined into a single street address in our listing verification system.
+                For a physical location this physical address of the business. Vendasta’s platform supports multiple address lines but currently those are combined into a single street address in our listing verification system.
               type: object
               properties:
                 Value:
@@ -367,7 +367,7 @@ components:
                   description: 'Does the phone number match the business’s first phone number in their Vendasta Business Profile. Toll free, cell and fax numbers are not considered even if they are the only number on the business profile.'
                   type: boolean
             website:
-              description: The website of the business entity.
+              description: The website of the business location.
               type: object
               properties:
                 value:
@@ -392,7 +392,7 @@ components:
               type: string
       x-tags:
         - Business Location Listings
-    businessEntityListingScore:
+    businessLocationListingScore:
       title: Business Location Listing Score
       type: object
       properties:

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -16,7 +16,7 @@ tags:
   - name: Listing Sync Listings
   - name: Options
 paths:
-  /listListingSyncListings:
+  /listingSyncListings:
     get:
       tags:
         - Listing Sync Listings
@@ -98,7 +98,7 @@ paths:
         - Options
         - Listing Sync Listings
     parameters: []
-  '/getListingScore/{id}':
+  '/listingScore/{id}':
     get:
       summary: Get Listing Score
       tags: []

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -16,11 +16,11 @@ tags:
   - name: Business Location Listings
   - name: Options
 paths:
-  /businessLocationListings:
+  /listListingSyncListings:
     get:
       tags:
         - Business Location Listings
-      summary: List Business Location Listings
+      summary: List Listing Sync Listings
       operationId: list-businessListings
       security:
         - OAuth2:
@@ -29,7 +29,7 @@ paths:
         status: trustedTester
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
-        Gets a list of listings for a business location
+        Gets a list of listings for a business location. This corresponds to the Listing Sync page in Listing Builder.
       parameters:
         - schema:
             type: string
@@ -98,9 +98,9 @@ paths:
         - Options
         - Business Location Listings
     parameters: []
-  '/businessLocationListingScores/{id}':
+  '/getListingScores/{id}':
     get:
-      summary: Get Business Location Listing Score
+      summary: Get Listing Score
       tags: []
       responses:
         '200':

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -98,7 +98,7 @@ paths:
         - Options
         - Listing Sync Listings
     parameters: []
-  '/listingScore/{id}':
+  '/listingScores/{id}':
     get:
       summary: Get Listing Score
       tags: []
@@ -111,8 +111,8 @@ paths:
                 type: object
                 properties:
                   data:
-                    $ref: '#/components/schemas/listingScore'
-      operationId: get-listingScore
+                    $ref: '#/components/schemas/listingScores'
+      operationId: get-listingScores
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
         Get the listing score information for a specific business
@@ -392,8 +392,8 @@ components:
               type: string
       x-tags:
         - Listing Sync Listings
-    listingScore:
-      title: Listing Score
+    listingScores:
+      title: Listing Scores
       type: object
       properties:
         id:

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -13,13 +13,13 @@ servers:
   - url: 'http://localhost:11001/products/listings'
     description: Localhost
 tags:
-  - name: Business Location Listings
+  - name: Listing Sync Listings
   - name: Options
 paths:
   /listListingSyncListings:
     get:
       tags:
-        - Business Location Listings
+        - Listing Sync Listings
       summary: List Listing Sync Listings
       operationId: list-businessListings
       security:
@@ -66,7 +66,7 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: '#/components/schemas/businessLocationListings'
+                      $ref: '#/components/schemas/listingSyncListings'
                   links:
                     type: object
                     properties:
@@ -96,7 +96,7 @@ paths:
           description: No Listing Product Active
       tags:
         - Options
-        - Business Location Listings
+        - Listing Sync Listings
     parameters: []
   '/getListingScores/{id}':
     get:
@@ -111,8 +111,8 @@ paths:
                 type: object
                 properties:
                   data:
-                    $ref: '#/components/schemas/businessLocationListingScore'
-      operationId: get-businessLocationListingScore
+                    $ref: '#/components/schemas/listingScore'
+      operationId: get-listingScore
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
         Get the listing score information for a specific business
@@ -149,7 +149,7 @@ components:
             listing: Access to the Listing Builder REST API
   schemas:
     businessLocationListings:
-      title: Business Location Listings
+      title: Listing Sync Listings
       type: object
       x-lifecycle:
         status: trustedTester
@@ -391,9 +391,9 @@ components:
                 notFound - No listing was found for this source by Vendasta.
               type: string
       x-tags:
-        - Business Location Listings
-    businessLocationListingScore:
-      title: Business Location Listing Score
+        - Listing Sync Listings
+    listingScore:
+      title: Listing Score
       type: object
       properties:
         id:

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -98,7 +98,7 @@ paths:
         - Options
         - Listing Sync Listings
     parameters: []
-  '/getListingScores/{id}':
+  '/getListingScore/{id}':
     get:
       summary: Get Listing Score
       tags: []

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -101,7 +101,8 @@ paths:
   '/listingScores/{id}':
     get:
       summary: Get Listing Score
-      tags: []
+      tags:
+        - Listing Scores
       responses:
         '200':
           description: OK
@@ -133,6 +134,16 @@ paths:
         name: id
         in: path
         required: true
+    options:
+      summary: List valid HTTP verbs for /listingScores
+      operationId: options-listingScores-id
+      responses:
+        '200':
+          description: OK
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly.'
+      tags:
+        - Options
+        - Listing Scores
 components:
   securitySchemes:
     JWT:

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -163,9 +163,9 @@ components:
           type: string
         type:
           type: string
-          default: listings
+          default: listingSyncListings
           enum:
-            - listings
+            - listingSyncListings
         attributes:
           type: object
           properties:
@@ -401,6 +401,9 @@ components:
           description: Vendasta's unique ID for the business
         type:
           type: string
+          default: listingScore
+          enum:
+            - listingScore
         attributes:
           type: object
           properties:

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -155,7 +155,7 @@ components:
         status: trustedTester
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
-        Gets a list of listings for a business location
+        A list of listings for a business location
       x-internal: false
       properties:
         id:
@@ -393,7 +393,7 @@ components:
       x-tags:
         - Business Location Listings
     businessEntityListingScore:
-      title: businessEntityListingScore
+      title: Business Location Listing Score
       type: object
       properties:
         id:
@@ -413,3 +413,7 @@ components:
             initialListingScore:
               type: integer
               description: The listing score of the business when Listing Builder was first activated
+      x-lifecycle: trustedTester
+      description: |-
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+        The listing score information for a business location


### PR DESCRIPTION
Changed business entity to business location.

Changed paths:
`businessEntityListings` to `listingSyncListings`
`businessEntityListingScores` to `listingScore`

@vendasta/insync 
@richard-rance 
@jredl-va 