### PR TITLE
feat: add page limit and cursor to platform.yaml

### DIFF
--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -1815,10 +1815,10 @@ paths:
             type: array
             items:
               type: string
-            enum:
-              - 'on'
-              - 'off'
-              - draining
+              enum:
+                - 'on'
+                - 'off'
+                - draining
             example: 'on'
           in: query
           name: 'filter[statuses]'
@@ -1843,8 +1843,6 @@ paths:
           description: Returns automations which have a trigger matching the provided value.
         - schema:
             type: array
-            items:
-              type: string
             example: default
           in: query
           name: 'filter[marketIds]'

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -1843,10 +1843,13 @@ paths:
           description: Returns automations which have a trigger matching the provided value.
         - schema:
             type: array
+            items:
+              type: string
             example: default
           in: query
           name: 'filter[marketIds]'
           description: Returns automations matching the provided market IDs.
+          required: true
       security:
         - OAuth2:
             - 'automation:read'

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -1843,6 +1843,8 @@ paths:
           description: Returns automations which have a trigger matching the provided value.
         - schema:
             type: array
+            items:
+              type: string
             example: default
           in: query
           name: 'filter[marketIds]'

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -1812,16 +1812,17 @@ paths:
           name: 'filter[name]'
           description: 'Returns automations which name''s partially match the provided string, case insensitive'
         - schema:
-            type: string
+            type: array
+            items:
+              type: string
             enum:
               - 'on'
               - 'off'
               - draining
-              - any
-            default: any
+            example: 'on'
           in: query
-          name: 'filter[status]'
-          description: 'Returns automations matching the provided state, can be one of: on, off, draining, any'
+          name: 'filter[statuses]'
+          description: 'Returns automations matching the provided state, can be: on, off, draining'
         - schema:
             type: array
             items:
@@ -1842,8 +1843,6 @@ paths:
           description: Returns automations which have a trigger matching the provided value.
         - schema:
             type: array
-            items:
-              type: string
             example: default
           in: query
           name: 'filter[marketIds]'

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -1827,8 +1827,8 @@ paths:
           in: query
           name: 'filter[tags]'
           description: Only return automations with all of the specified tags. You may either provide a comma-separated list of tags or specify the parameter multiple times.
-        - $ref: ../advertising/advertising.yaml#/components/parameters/pageCursor
-        - $ref: ../advertising/advertising.yaml#/components/parameters/pageLimit
+        - $ref: '#/components/parameters/pageCursor'
+        - $ref: '#/components/parameters/pageLimit'
         - schema:
             type: string
             enum:
@@ -3235,6 +3235,24 @@ paths:
         - Options
         - Product Custom Fields
 components:
+  parameters:
+    pageLimit:
+      name: 'page[limit]'
+      in: query
+      required: false
+      schema:
+        type: number
+        maximum: 100
+        minimum: 1
+        default: 25
+      description: The maximum number of items you would like returned in a single batch. Use the links.next member in the response to get the next batch.
+    pageCursor:
+      name: 'page[cursor]'
+      in: query
+      required: false
+      schema:
+        type: string
+      description: The cursor stores all your filters and current location in the list to allow paging over the results in smaller batches. The value will be provided in the response links.
   securitySchemes:
     JWT:
       type: http

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -1840,6 +1840,14 @@ paths:
           in: query
           name: 'filter[trigger]'
           description: Returns automations which have a trigger matching the provided value.
+        - schema:
+            type: array
+            items:
+              type: string
+            example: default
+          in: query
+          name: 'filter[marketIds]'
+          description: Returns automations matching the provided market IDs.
       security:
         - OAuth2:
             - 'automation:read'

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -1824,6 +1824,8 @@ paths:
           description: 'Returns automations matching the provided state, can be one of: on, off, draining, any'
         - schema:
             type: array
+            items:
+              type: string
           in: query
           name: 'filter[tags]'
           description: Only return automations with all of the specified tags. You may either provide a comma-separated list of tags or specify the parameter multiple times.


### PR DESCRIPTION
It turns out that you can't reference things outside the file. I think this is cause the file structure changes when you use `inv vendor:oas`. This adds the page refs into the platform.yaml so I can use it there.

auto-2047

@vendasta/autobots @richard-rance 