### PR TITLE
FIx the sales message in description

### DIFF
--- a/openapi/social/social.yaml
+++ b/openapi/social/social.yaml
@@ -85,7 +85,11 @@ paths:
         status: trustedTester
   /messages:
     post:
-      summary: Kindly contact `Sales` to know more about the scheduling API.
+    summary: Schedule Message
+    operationId: post-messages
+    
+    description: |-
+      Please contact Sales to know more about scheduling message API
 
 components:
   securitySchemes:


### PR DESCRIPTION
FIx the `schedule message API` contact `sales` reference from header to description