### PR TITLE
feat: Expose apis for list get and update customer operations

### DIFF
--- a/openapi/business/business.yaml
+++ b/openapi/business/business.yaml
@@ -251,7 +251,7 @@ paths:
         - schema:
             type: string
           in: query
-          name: 'filter[businesses.id]'
+          name: 'filter[businessLocation.id]'
           description: Return customers for the specified business location
           required: true
         - schema:

--- a/openapi/business/business.yaml
+++ b/openapi/business/business.yaml
@@ -264,6 +264,27 @@ paths:
           in: query
           description: The maximum number of tasks you would like returned in a single batch. Use the links.next member in the response to get the remainder.
           name: 'page[limit]'
+        - schema:
+            type: string
+            enum:
+              - createdAt
+              - '-createdAt'
+              - givenName
+              - '-givenName'
+              - familyName
+              - '-familyName'
+            default: '-createdAt'
+            example: 'familyName'
+          in: query
+          name: sort
+          description: |-
+            The order to sort the results in. Only one sort parameter may be provided:
+              - `createdAt`: Created at ascending
+              - `-createdAt`: Created at descending
+              - `givenName`: Given name ascending
+              - `-givenName`: Given name descending
+              - `familyName`: Family name ascending
+              - `-familyName`: Family name descending
       security:
         - OAuth2:
             - customers

--- a/openapi/business/business.yaml
+++ b/openapi/business/business.yaml
@@ -208,6 +208,183 @@ paths:
       tags:
         - Customers
         - Options
+    get:
+      summary: List Customers
+      operationId: get-customers
+      responses:
+        '200':
+          description: OK
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/customers'
+                  links:
+                    type: object
+                    properties:
+                      self:
+                        type: string
+                        format: uri
+                      first:
+                        type: string
+                        description: Provides a link back to the first page of results
+                        format: uri
+                      next:
+                        type: string
+                        description: The URI at which the next batch of customers can be gotten from
+                        format: uri
+      description: |-
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+
+        Produces a list of customers
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Authorization
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          required: true
+        - schema:
+            type: string
+          in: query
+          name: 'filter[businesses.id]'
+          description: Return customers for the specified business location
+          required: true
+        - schema:
+            type: string
+          in: query
+          description: The cursor stores all your filters and current location in the list to allow paging over the results in smaller batches. The value will be provided in the response links.
+          name: 'page[cursor]'
+        - schema:
+            type: string
+          in: query
+          description: The maximum number of tasks you would like returned in a single batch. Use the links.next member in the response to get the remainder.
+          name: 'page[limit]'
+      security:
+        - OAuth2:
+            - customers
+      tags:
+        - Customers
+      x-lifecycle:
+        status: trustedTester
+  '/customers/{id}':
+    parameters:
+      - schema:
+          type: string
+        name: id
+        in: path
+        required: true
+    get:
+      summary: Get Customer
+      tags:
+        - Customers
+      responses:
+        '200':
+          description: OK
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/customers'
+                  links:
+                    type: object
+                    properties:
+                      self:
+                        type: string
+      operationId: get-customers-id
+      x-lifecycle:
+        status: trustedTester
+      description: |-
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+
+        Fetch the current values for the specified customer.
+      parameters:
+        - schema:
+            type: string
+            example: Bearer <Access Token>
+            pattern: ^Bearer\s\S+
+          in: header
+          name: Authorization
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          required: true
+      security:
+        - OAuth2:
+            - business
+    options:
+      operationId: options-customers-id
+      summary: 'List valid HTTP verbs for /customers/{id}'
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
+      responses:
+        '204':
+          description: No Content
+      tags:
+        - Options
+        - Customers
+    patch:
+      summary: Update Customer
+      operationId: patch-customers-id
+      tags:
+        - Customers
+      description: |-
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+
+        Update the existing customer.
+        Only the root ID and type fields are required. All others are optional and will keep their original value if omitted.
+      x-lifecycle:
+        status: trustedTester
+      parameters:
+        - schema:
+            type: string
+            example: Bearer <Access Token>
+            pattern: ^Bearer\s\S+
+          in: header
+          name: Authorization
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          required: true
+        - schema:
+            type: string
+            default: application/vnd.api+json
+            enum:
+              - application/vnd.api+json
+          in: header
+          name: Content-Type
+          required: true
+          description: Indicates the format of the request body being sent. In most cases you will want `application/vnd.api+json`
+      security:
+        - OAuth2:
+            - customers
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/customers'
+                  links:
+                    type: object
+                    properties:
+                      self:
+                        type: string
+                        format: uri
+                        description: The address of the updated customer
+          headers: {}
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: '#/components/schemas/customers'
 components:
   securitySchemes:
     JWT:
@@ -230,7 +407,7 @@ components:
         
         A customer is a person a business location has had a prior business relationship with and permission to contact.
         
-        Customer records are displayed within Business App. If you are looking for contacts within Sales and Success Center, see Sales Contact.
+        Customer records are displayed within Business App and are available to marketplace products. If you are looking for contacts within Sales and Success Center, see Sales Contact.
       type: object
       x-examples:
         Example Customer:

--- a/openapi/business/business.yaml
+++ b/openapi/business/business.yaml
@@ -313,12 +313,6 @@ paths:
           name: Authorization
           description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
           required: true
-        - schema:
-            type: string
-          in: query
-          name: 'filter[businesses.id]'
-          description: Return customers for the specified business location
-          required: true
       security:
         - OAuth2:
             - business

--- a/openapi/business/business.yaml
+++ b/openapi/business/business.yaml
@@ -315,7 +315,7 @@ paths:
           required: true
       security:
         - OAuth2:
-            - business
+            - customers
     options:
       operationId: options-customers-id
       summary: 'List valid HTTP verbs for /customers/{id}'

--- a/openapi/business/business.yaml
+++ b/openapi/business/business.yaml
@@ -135,7 +135,7 @@ paths:
                 readOnly: true
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
-        
+
         Used to create a new customer record within Business App.
 
         The following members must be populated during creation:
@@ -313,6 +313,12 @@ paths:
           name: Authorization
           description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
           required: true
+        - schema:
+            type: string
+          in: query
+          name: 'filter[businesses.id]'
+          description: Return customers for the specified business location
+          required: true
       security:
         - OAuth2:
             - business
@@ -404,9 +410,9 @@ components:
       title: Customers
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
-        
+
         A customer is a person a business location has had a prior business relationship with and permission to contact.
-        
+
         Customer records are displayed within Business App and are available to marketplace products. If you are looking for contacts within Sales and Success Center, see Sales Contact.
       type: object
       x-examples:

--- a/openapi/business/business.yaml
+++ b/openapi/business/business.yaml
@@ -313,6 +313,12 @@ paths:
           name: Authorization
           description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
           required: true
+        - schema:
+            type: string
+          in: query
+          name: 'filter[businesses.id]'
+          description: Return customers for the specified business location
+          required: true
       security:
         - OAuth2:
             - business

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -253,7 +253,7 @@ paths:
                         format: uri
                       next:
                         type: string
-                        description: The URI at which the next batch of purchases can be gotten from
+                        description: The URI at which the next batch of business locations can be gotten from
                         format: uri
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
@@ -508,7 +508,7 @@ paths:
                         format: uri
                       next:
                         type: string
-                        description: The URI at which the next batch of purchases can be gotten from
+                        description: The URI at which the next batch of users can be gotten from
                         format: uri
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
@@ -882,7 +882,7 @@ paths:
                         format: uri
                       next:
                         type: string
-                        description: The URI at which the next batch of purchases can be gotten from
+                        description: The URI at which the next batch of business categories can be gotten from
                         format: uri
               examples: {}
     options:
@@ -1001,7 +1001,7 @@ paths:
                         format: uri
                       next:
                         type: string
-                        description: The URI at which the next batch of purchases can be gotten from
+                        description: The URI at which the next batch of orders can be gotten from
                         format: uri
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
@@ -1382,7 +1382,7 @@ paths:
                         format: uri
                       next:
                         type: string
-                        description: The URI at which the next batch of purchases can be gotten from
+                        description: The URI at which the next batch of fields can be gotten from
                         format: uri
               examples:
                 Return Example:
@@ -1781,7 +1781,7 @@ paths:
                         example: 'https://prod.apigateway.co/platform/automations?filter[businessPartner.id]=ABC&page[cursor]=&page[limit]=1'
                       next:
                         type: string
-                        description: The URI at which the next batch of purchases can be gotten from
+                        description: The URI at which the next batch of automations can be gotten from
                         format: uri
                         example: 'https://prod.apigateway.co/platform/automations?filter[businessPartner.id]=ABC&page[cursor]=Cg8aDUFHLTIyV1YyODVKSjY=&page[limit]=1'
               examples: {}
@@ -2088,7 +2088,7 @@ paths:
                         format: uri
                       next:
                         type: string
-                        description: The URI at which the next batch of purchases can be gotten from
+                        description: The URI at which the next batch of accounts can be gotten from
                         format: uri
               examples:
                 Return Example:
@@ -2732,7 +2732,7 @@ paths:
                         format: uri
                       next:
                         type: string
-                        description: The URI at which the next batch of purchases can be gotten from
+                        description: The URI at which the next batch of fields can be gotten from
                         format: uri
               examples:
                 Return Example:
@@ -2923,7 +2923,7 @@ paths:
                         format: uri
                       next:
                         type: string
-                        description: The URI at which the next batch of purchases can be gotten from
+                        description: The URI at which the next batch of fields can be gotten from
                         format: uri
               examples:
                 Return Example:
@@ -3378,7 +3378,7 @@ paths:
                         format: uri
                       next:
                         type: string
-                        description: The URI at which the next batch of purchases can be gotten from
+                        description: The URI at which the next batch of fields can be gotten from
                         format: uri
               examples:
                 Return Example:


### PR DESCRIPTION
@vendasta/external-apis
@vendasta/data-busters 
@DewaldoDev  (if you have time to review) 
@hchow-va (if you have time to review)

Expose apis for list, get and update. This extends the existing create customer api that exists. Note, that I've removed some of the "business app" verbiage as we want to ensure its understood that these apis can be used by marketplace / smb products. 