### PR TITLE
Fix create proposalTemplate example

### DIFF
--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -4203,7 +4203,7 @@ paths:
             type: string
           in: query
           name: 'filter[searchTerm]'
-          description: A string containing a partial title. 
+          description: A string containing a partial title.
       security:
         - OAuth2:
             - sales.proposals
@@ -7138,7 +7138,7 @@ components:
           properties:
             templateType:
               type: string
-              example: widgetTemplate
+              example: pageTemplate
               default: proposalTemplate
               enum:
                 - widgetTemplate


### PR DESCRIPTION
The first element type is a page element, so the default type needs to be pageTemplate. Otherwise the example will attempt to create a widget template with a page as the top-level element.

@vendasta/external-apis
@richard-rance 

**TODO**:
- [x] Review the [pre release checklist](https://vendasta.jira.com/wiki/spaces/API/pages/1651769533/Pre+Release+Checks)
