### PR TITLE
Fix operation ids for proposalTemplate requests

### DIFF
--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -4116,7 +4116,7 @@ paths:
   /proposalTemplates:
     get:
       summary: List Proposal Templates
-      operationId: get-proposals
+      operationId: get-proposalTemplates
       responses:
         '200':
           description: OK
@@ -4224,7 +4224,7 @@ paths:
 
         *CreatorOrganization is required*
       summary: Create Proposal Template
-      operationId: post-proposals
+      operationId: post-proposalTemplates
       parameters:
         - schema:
             type: string


### PR DESCRIPTION
@vendasta/external-apis

Possible fix for the issue shown in video below:

https://user-images.githubusercontent.com/82058487/193891003-60afdafd-6bab-45a5-8b33-ffe025510110.mov

**TODO**:
- [x] Review the [pre release checklist](https://vendasta.jira.com/wiki/spaces/API/pages/1651769533/Pre+Release+Checks)
