### PR TITLE
Update social yaml with OAuthDemo,OAuthProd

### DIFF
--- a/openapi/social/social.yaml
+++ b/openapi/social/social.yaml
@@ -160,12 +160,21 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-    OAuth2:
+    OAuth2Demo:
       type: oauth2
       flows:
         authorizationCode:
           authorizationUrl: 'https://sso-api-demo.apigateway.co/oauth2/auth'
           tokenUrl: 'https://sso-api-demo.apigateway.co/oauth2/token'
+          scopes:
+            business: Read-write access to business details
+            social: Read-write access to Social Marketing APIs
+    OAuth2Prod:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://sso-api-prod.apigateway.co/oauth2/auth'
+          tokenUrl: 'https://sso-api-prod.apigateway.co/oauth2/token'
           scopes:
             business: Read-write access to business details
             social: Read-write access to Social Marketing APIs
@@ -360,6 +369,9 @@ tags:
   - name: Messages
   - name: Options
 security:
-  - OAuth2:
+  - OAuth2Demo:
+      - business
+      - social
+  - OAuth2Prod:
       - business
       - social


### PR DESCRIPTION
@vendasta/external-apis
@vendasta/phoenix 

Since api-gateway repo sync `social.yaml` file from here, it is better to update the file with OAuth2Demo & OAuth2Prod. So that `inv vendor:oas` sync, will not make the unit test to fail.

**TODO**:
- [ ] Review the [pre release checklist](https://vendasta.jira.com/wiki/spaces/API/pages/1651769533/Pre+Release+Checks)
