### PR TITLE
fix(business location reviews): change type of filter[businessListing.id] to string

### DIFF
--- a/openapi/reputation/reputation.yaml
+++ b/openapi/reputation/reputation.yaml
@@ -46,7 +46,7 @@ paths:
           description: Return reviews for the specified business location
           required: true
         - schema:
-            type: integer
+            type: string
           in: query
           name: 'filter[businessListing.id]'
           description: Return reviews for a specific business listing


### PR DESCRIPTION
All of our listing ids are of the format `LIS-804D842ABC0743AC8E345126911477DC`. That is not an integer, so change the type to a string.

REP-476

@vendasta/external-apis @vendasta/redmagic 

**TODO**:
- [ ] Review the [pre release checklist](https://vendasta.jira.com/wiki/spaces/API/pages/1651769533/Pre+Release+Checks)
