### PR TITLE
chore(reputation): change suggest review response to trusted tester

### DIFF
--- a/openapi/reputation/reputation.yaml
+++ b/openapi/reputation/reputation.yaml
@@ -150,9 +150,9 @@ paths:
         - OAuth2Prod:
             - business
       x-lifecycle:
-        status: proposed
+        status: trustedTester
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
 
         Asks AI for a suggested response to the review
       parameters:
@@ -244,7 +244,7 @@ components:
       x-lifecycle:
         status: trustedTester
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
 
         A suggested response to a business location review
       properties:


### PR DESCRIPTION
### Issue
Implementation for the suggest review response API was done in https://github.com/vendasta/api-gateway/pull/329. The docs should be updated from proposed to trusted tester

### Solution
Do that.

@vendasta/external-apis @vendasta/redmagic 
[REP-475]

[REP-475]: https://vendasta.jira.com/browse/REP-475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ