### PR TITLE
chore(spectral): remove unneeded token

### DIFF
--- a/.spectral.mjs
+++ b/.spectral.mjs
@@ -1,2 +1,2 @@
-import ruleset from "https://stoplight.io/api/v1/projects/cHJqOjE1ODI5/spectral.js?branch_slug=master&token=2bae0758-cb25-4ec3-a196-7bc6e94a1cba";
+import ruleset from "https://stoplight.io/api/v1/projects/cHJqOjE1ODI5/spectral.js?branch_slug=master";
 export default { extends: ruleset };


### PR DESCRIPTION
### Problem
A HackerOne report was created detailing apparent API tokens disclosed in plaintext.

### Solution
The token doesn't appear to be needed for accessing the spectral.js file, nor does it seem to grant access to any sensitive files or API endpoints (it may have been needed at one point when this file was private?). To avoid future reports, I am removing it. If we do find out where this token came from, we can probably delete it or rotate it if required.

@vendasta/external-apis @richard-rance 