### PR TITLE
LIS-1048 Update citation page limit docs

### DIFF
--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -333,7 +333,7 @@ paths:
             type: string
           in: query
           name: 'page[limit]'
-          description: 'For now we only support a value of 200. [Pagination Docs](https://developers.vendasta.com/platform/ZG9jOjEwMTkzMDg0-overview#paging).'
+          description: '[Pagination Docs](https://developers.vendasta.com/platform/ZG9jOjEwMTkzMDg0-overview#paging).'
     options:
       operationId: options-citationData
       summary: List valid HTTP verbs for /citations


### PR DESCRIPTION
This line about the 200 pagination limit no longer applies, as the default min and max of 10 and 100 will be applied to this endpoint's pagination

@vendasta/external-apis

**TODO**:
- [x] Review the [pre release checklist](https://vendasta.jira.com/wiki/spaces/API/pages/1651769533/Pre+Release+Checks)
