### PR TITLE
chore(find sku): add RM premium edition

### DIFF
--- a/docs/Guides/Sell/FindSKU.md
+++ b/docs/Guides/Sell/FindSKU.md
@@ -52,6 +52,7 @@ Product | Production SKU | Demo SKU
 --------|----------------|---------
  Express |RM:EDITION-F7JZ5TV8 | RM:EDITION-38SMW45H
  Pro | RM | RM
+ Premium | RM:EDITION-JFRPLQPN | RM:EDITION-BFXF8W8Q
 
 The base Reputation Management product must be already active or included in the same order as any of the addons.
 

--- a/docs/Overview/Changelog.md
+++ b/docs/Overview/Changelog.md
@@ -2,6 +2,9 @@
 
 The platform is continuously evolving. This page lists the significant changes when they are announced. For more info on the statuses and release process see [Versioning](./Versioning.md)
 
+## 2023-10-24
+Add Reputation Management Premium edition ID under `Find SKU`
+
 ## 2023-08-28
 Update the product name for Listing Builder to Local SEO, added the new editions, and added Additional Keyword addon SKUs.
 


### PR DESCRIPTION
### Issue
We now have Reputation Management Premium, but it was not added to the docs yet.

### Solution
Add it where the editions for Reputation Management are listed in the `findSKU` page.

I remember having to pull into updates to `api-gateway`, but I'm guessing that's not necessary this time since it's purely a text change and not something to do with a particular endpoint?

**TODO**:
- [x] Review the [pre release checklist](https://vendasta.jira.com/wiki/spaces/API/pages/1651769533/Pre+Release+Checks)

@vendasta/external-apis
[REP-549]

[REP-549]: https://vendasta.jira.com/browse/REP-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ