### PR TITLE
feat: Add tollFreeNumber, callTrackingNumbers, commonNames to businessLocations and salesAccounts

### DIFF
--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -5330,6 +5330,34 @@ components:
             updatedAt:
               type: string
               description: The time at which the business locations was last updated
+            tollFreeNumber:
+              type: string
+              x-stoplight:
+                id: osrb4z5e7kdm2
+              description: The toll free number for the business.
+            callTrackingNumbers:
+              type:
+                - array
+              x-stoplight:
+                id: 4a4pt5e0kkxan
+              description: A call tracking number is a phone number that gathers analytics for inbound calls. Call tracking is commonly used as a method of performance assessment for marketing campaigns.
+              minItems: 0
+              maxItems: 6
+              items:
+                x-stoplight:
+                  id: p7k0otyb8h17q
+                type: string
+            commonNames:
+              type: array
+              x-stoplight:
+                id: 4k2d33t7kl1hy
+              maxItems: 3
+              minItems: 0
+              description: Other names that your business is commonly called (Ex. Patty's Irish Pub referred to as Patty's or Patty's Pub).
+              items:
+                x-stoplight:
+                  id: t1gp8neeat4ym
+                type: string
         relationships:
           type: object
           properties:
@@ -6614,10 +6642,14 @@ components:
               minLength: 1
             commonNames:
               type: array
-              description: A common name for a business (Something it is often referred to as)
-              maxItems: 3
+              x-stoplight:
+                id: u4s0f7byct6ig
               minItems: 0
+              maxItems: 3
+              description: Other names that your business is commonly called (Ex. Patty's Irish Pub referred to as Patty's or Patty's Pub).
               items:
+                x-stoplight:
+                  id: xnw94m062tmbz
                 type: string
             address:
               type: object
@@ -6732,6 +6764,22 @@ components:
             updatedAt:
               type: string
               description: The time at which the sales accounts was last updated
+            tollFreeNumber:
+              type: string
+              x-stoplight:
+                id: eke0wqk8yvgmh
+              description: The toll free number for the business.
+            callTrackingNumbers:
+              type: array
+              x-stoplight:
+                id: eyhgi2yh7ukaf
+              minItems: 0
+              maxItems: 6
+              description: A call tracking number is a phone number that gathers analytics for inbound calls. Call tracking is commonly used as a method of performance assessment for marketing campaigns.
+              items:
+                x-stoplight:
+                  id: yflmky9gif6ro
+                type: string
         relationships:
           type: object
           properties:

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -6642,14 +6642,10 @@ components:
               minLength: 1
             commonNames:
               type: array
-              x-stoplight:
-                id: u4s0f7byct6ig
-              minItems: 0
+              description: A common name for a business (Something it is often referred to as)
               maxItems: 3
-              description: Other names that your business is commonly called (Ex. Patty's Irish Pub referred to as Patty's or Patty's Pub).
+              minItems: 0
               items:
-                x-stoplight:
-                  id: xnw94m062tmbz
                 type: string
             address:
               type: object


### PR DESCRIPTION
Update BusinessLocations and SalesAccounts models to have the new fields `tollFreeNumber`, `callTrackingNumbers`, `commonNames`. 

The wording of the descriptions of the fields are subject to change still

@vendasta/pioneers 
@vendasta/external-apis

**TODO**:
- [x] Review the [pre release checklist](https://vendasta.jira.com/wiki/spaces/API/pages/1651769533/Pre+Release+Checks)
