### PR TITLE
[SM-1134] Schedule social post doc update

### DIFF
--- a/openapi/social/social.yaml
+++ b/openapi/social/social.yaml
@@ -100,7 +100,7 @@ paths:
       description: |-
         [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
 
-        This operation will schedule a new message to be posted at the time defined in `sendAt` (this defaults to posting in 5 minutes if no `sendAt` is given)
+        This operation will schedule a new message to be posted at the time defined in `scheduledAt` (this defaults to posting in 5 minutes if no `scheduledAt` is given)
 
         If scheduling was successful, it will return the Message with an id. If there are validation errors on scheduling for any of the services listed, it will instead give a list of errors.
       requestBody:
@@ -196,10 +196,10 @@ paths:
           description: The maximum number of Social Posts you would like to return.
         - schema:
             type: string
-            example: 'Jd6889Js3'
+            example: Jd6889Js3
           in: query
           name: 'filter[socialProfileExternalIds]'
-          description: 'A comma-seperated list filtering messages to profiles with these external identifiers.'
+          description: A comma-seperated list filtering messages to profiles with these external identifiers.
         - schema:
             type: string
             example: '2022-02-04T16:52:34.000Z'
@@ -351,6 +351,7 @@ components:
         id:
           type: string
           description: A unique identifier assigned to this message. We will automatically assign the Message one on creation.
+          readOnly: true
         type:
           type: string
           default: messages
@@ -401,6 +402,7 @@ components:
 
                 Times used must be in ISO 8601 format, UTC time.
               example: '2022-02-04T16:52:34.000Z'
+              readOnly: true
             scheduledAt:
               type: string
               format: date-time
@@ -489,6 +491,7 @@ components:
                     type:
                       type: string
                       default: businessLocations
+                      readOnly: true
                     id:
                       type: string
           required:

--- a/openapi/social/social.yaml
+++ b/openapi/social/social.yaml
@@ -292,7 +292,7 @@ components:
               description: The name of this profile.
             avatarUrl:
               type: string
-              description: The link to an url for the avatar image of this profile.
+              description: The links to an url for the avatar image of this profile.
             socialNetwork:
               type: string
               description: A string enum representing which social network this Social Profile is on.

--- a/openapi/social/social.yaml
+++ b/openapi/social/social.yaml
@@ -292,7 +292,7 @@ components:
               description: The name of this profile.
             avatarUrl:
               type: string
-              description: The links to an url for the avatar image of this profile.
+              description: The link to an url for the avatar image of this profile.
             socialNetwork:
               type: string
               description: A string enum representing which social network this Social Profile is on.


### PR DESCRIPTION
# Schedule social post doc update

Updated some changes in POST message endpoint documentation

Reference : [SM-1134](https://vendasta.jira.com/browse/SM-1134)

## Changes
Changed sendAt to scheduledAt
<img width="560" alt="Screenshot 2024-03-04 at 4 48 36 PM" src="https://github.com/vendasta/api-gateway-docs/assets/153067020/3787ebd4-0ce6-4148-a6c9-6d24dc7bbf1c">

Made these fields unexposed (id, media->type, postedAt, relationships->socialProfiles->data->type , relationships->businessLocation->data->type)
<img width="586" alt="Screenshot 2024-03-04 at 4 49 35 PM" src="https://github.com/vendasta/api-gateway-docs/assets/153067020/6d724561-ed3b-4b05-bd62-241cb3c11c74">


**TODO**:
- [ ] Review the [pre release checklist](https://vendasta.jira.com/wiki/spaces/API/pages/1651769533/Pre+Release+Checks)


@vendasta/tots 
@vendasta/external-apis
@richard-rance 

[SM-1134]: https://vendasta.jira.com/browse/SM-1134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ