### PR TITLE
LIS-1586 Update Listings Docs

### DIFF
--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -649,7 +649,7 @@ components:
       x-examples:
         Example 1:
           id: AG-1234567
-          type: businessLocations
+          type: listingProfiles
           attributes:
             customerIdentifier: customer 123
             name: Fred's Fish

--- a/openapi/listings/listings.yaml
+++ b/openapi/listings/listings.yaml
@@ -33,7 +33,7 @@ paths:
       x-lifecycle:
         status: proposed
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
         Gets a list of listings for a listing profile. This corresponds to the  Business Profile page in Local SEO.
       parameters:
         - schema:
@@ -48,18 +48,6 @@ paths:
             type: string
           in: query
           name: 'filter[businessLocation.id]'
-          required: true
-          deprecated: true
-          description: Deprecated - This field has been replaced by listingProfile.id
-          x-lifecycle:
-            status: deprecated
-            deprecated: '2023-06-07'
-            proposedRemoval: '2023-06-08'
-            description: This field was replaced by listingProfileId while at the proposed phase. It will be removed shortly.
-        - schema:
-            type: string
-          in: query
-          name: 'filter[listingProfile.id]'
           description: Return listings for the specified listing profile for the Vendasta's unique ID for the business
           required: true
         - schema:
@@ -132,7 +120,7 @@ paths:
                     $ref: '#/components/schemas/listingScores'
       operationId: get-listingScores
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
         Get the listing score information for a specific business
       x-lifecycle:
         status: proposed
@@ -303,7 +291,7 @@ paths:
                         format: uri
       operationId: get-citationData
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
         Get the citation data information for a specific business. The citations that are returned are sorted by the `foundAt` property in descending order.
       x-lifecycle:
         status: proposed


### PR DESCRIPTION
Update the status of implemented endpoints from `Proposed` to `Trusted Tester`.  Remove the `listingProfile.id` parameter in our `List Listing Sync Listings` endpoint in favor of the `businessProfile.id` one, since it is the parameter we use for other endpoints as well.

@vendasta/external-apis

**TODO**:
- [x] Review the [pre release checklist](https://vendasta.jira.com/wiki/spaces/API/pages/1651769533/Pre+Release+Checks)
