### PR TITLE
[MRNA-1164] - Pagination Limit of 10,000 Records for List Business Location Reviews

### DIFF
--- a/openapi/reputation/reputation.yaml
+++ b/openapi/reputation/reputation.yaml
@@ -89,7 +89,7 @@ paths:
             type: string
           in: query
           name: 'page[cursor]'
-          description: 'The cursor stores all your filters and current location in the list to allow paging over the results in smaller batches. The value will be provided in the response links. Please note that users can retrieve a maximum of 10,000 records in a single page due to paging limitations. [Pagination Docs](https://developers.vendasta.com/platform/ZG9jOjEwMTkzMDg0-overview#paging).'
+          description: 'The cursor stores all your filters and current location in the list to allow paging over the results in smaller batches. The value will be provided in the response links. Please note that users can retrieve a maximum of 10,000 records due to paging limitations. [Pagination Docs](https://developers.vendasta.com/platform/ZG9jOjEwMTkzMDg0-overview#paging).'
         - schema:
             type: string
           in: header

--- a/openapi/reputation/reputation.yaml
+++ b/openapi/reputation/reputation.yaml
@@ -89,7 +89,7 @@ paths:
             type: string
           in: query
           name: 'page[cursor]'
-          description: 'The cursor stores all your filters and current location in the list to allow paging over the results in smaller batches. The value will be provided in the response links. Please note that users can retrieve a maximum of 10,000 records due to paging limitations. [Pagination Docs](https://developers.vendasta.com/platform/ZG9jOjEwMTkzMDg0-overview#paging).'
+          description: 'The cursor stores all your filters and current location in the list to allow paging over the results in smaller batches. The value will be provided in the response links. Please note that users can retrieve a maximum of 10,000 records in a single page due to paging limitations. [Pagination Docs](https://developers.vendasta.com/platform/ZG9jOjEwMTkzMDg0-overview#paging).'
         - schema:
             type: string
           in: header

--- a/openapi/reputation/reputation.yaml
+++ b/openapi/reputation/reputation.yaml
@@ -89,7 +89,7 @@ paths:
             type: string
           in: query
           name: 'page[cursor]'
-          description: 'The cursor stores all your filters and current location in the list to allow paging over the results in smaller batches. The value will be provided in the response links. [Pagination Docs](https://developers.vendasta.com/platform/ZG9jOjEwMTkzMDg0-overview#paging).'
+          description: 'The cursor stores all your filters and current location in the list to allow paging over the results in smaller batches. The value will be provided in the response links. Please note that users can retrieve a maximum of 10,000 records due to paging limitations. [Pagination Docs](https://developers.vendasta.com/platform/ZG9jOjEwMTkzMDg0-overview#paging).'
         - schema:
             type: string
           in: header
@@ -223,7 +223,7 @@ components:
               format: date-time
               type: string
             editedAt:
-              description: Date of when the review was edited on the source site, currently it is only supported on Google and Facebook reviews
+              description: 'Date of when the review was edited on the source site, currently it is only supported on Google and Facebook reviews'
               format: date-time
               type: string
             comments:


### PR DESCRIPTION
[MRNA-1164](https://vendasta.jira.com/browse/MRNA-1164): Documentation Update: Pagination Limit of 10,000 Records for List Business Location Reviews

**Changes**: Updated the description of cursor for List Business Location Reviews

@vendasta/external-apis 

**TODO**:
- [x] Review the [pre release checklist](https://vendasta.jira.com/wiki/spaces/API/pages/1651769533/Pre+Release+Checks)


[MRNA-1164]: https://vendasta.jira.com/browse/MRNA-1164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ