### PR TITLE
Add undo cancellation api endpoint

### DIFF
--- a/openapi/crm/crm.json
+++ b/openapi/crm/crm.json
@@ -68,7 +68,7 @@
                     "value": {
                       "type": "object",
                       "title": "CRM FieldSchema of Contact",
-                      "description": "CRM Field Schema of resourceType Contact for the partner 9YW9",
+                      "description": "CRM Field Schema of resourceType Contact.",
                       "properties": {
                         "platform__contact_additional_salesperson_ids": {
                           "description": "Identifiers for additional salespeople in the platform.",
@@ -704,7 +704,7 @@
       "CRMContact": {
         "type": "object",
         "title": "CRM FieldSchema of Contact",
-        "description": "CRM Field Schema of resourceType Contact for the partner 9YW9",
+        "description": "CRM Field Schema of resourceType Contact.",
         "properties": {
           "platform__contact_additional_salesperson_ids": {
             "description": "Identifiers for additional salespeople in the platform.",

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -3061,13 +3061,16 @@ paths:
                 deactivationType:
                   type: string
                   description: |-
-                    `cancel` cancel indicates we should turn the product or service off at the anniversary date, or commitment date, whichever is later and till then it will be available for use.
+                    `cancel` indicates we should turn the product or service off at the anniversary date, or commitment date, whichever is later and till then it will be available for use.
 
-                    `immediate` Immediate indicates we should turn the product or service off immediately and it will no longer be available to use.
+                    `immediate` indicates we should turn the product or service off immediately and it will no longer be available to use.
+                    
+                    `restore` indicates that we should undo the cancellation.
                   default: cancel
                   enum:
                     - cancel
                     - immediate
+                    - restore
             examples:
               Example 1:
                 value:

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -3070,7 +3070,6 @@ paths:
                   enum:
                     - cancel
                     - immediate
-                    - restore
             examples:
               Example 1:
                 value:
@@ -3082,6 +3081,53 @@ paths:
     options:
       summary: 'List valid HTTP verbs for /subscriptionAssignments/{id}/actions/requestCancellation'
       operationId: options-subscriptionAssignment-requestCancellationAction
+      responses:
+        '204':
+          description: No Content
+      description: 'Used solely for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) the OPTIONS request returns the list of possible HTTP methods and other headers that browsers use to protect user''s security. You should not call this operation directly. '
+      tags:
+        - Options
+        - Subscription Assignments
+  '/subscriptionAssignments/{id}/actions/undoCancellation':
+    parameters:
+      - schema:
+          type: string
+          example: 'AG-CQD6ZR6:MP-R7G3NP55T725DM5VGD:beff34a4-cccc-4be8-bd9'
+        name: id
+        in: path
+        required: true
+        description: 'The id should be a string which is in the form - businessLocationId : productId : activationId'
+    post:
+      summary: Restore a Canceled Subscription Assignment
+      responses:
+        '204':
+          description: No Content
+      description: |-
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+
+        Used for restoring a canceled subscription assignment.
+      tags:
+        - Subscription Assignments
+      x-lifecycle:
+        status: proposed
+      operationId: restore-subscriptionAssignments-by-id
+      security:
+        - OAuth2Demo:
+            - sales.account
+        - OAuth2Prod:
+            - sales.account
+      parameters:
+        - schema:
+            type: string
+            example: Bearer <Access Token>
+            pattern: ^Bearer\s\S+
+          in: header
+          description: A Bearer access token to identify the user the app is acting on behalf of. See the Authorization guide for details.
+          name: Authorization
+          required: true
+    options:
+      summary: 'List valid HTTP verbs for /subscriptionAssignments/{id}/actions/undoCancellation'
+      operationId: options-subscriptionAssignment-undoCancellationAction
       responses:
         '204':
           description: No Content

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -3064,8 +3064,6 @@ paths:
                     `cancel` indicates we should turn the product or service off at the anniversary date, or commitment date, whichever is later and till then it will be available for use.
 
                     `immediate` indicates we should turn the product or service off immediately and it will no longer be available to use.
-                    
-                    `restore` indicates that we should undo the cancellation.
                   default: cancel
                   enum:
                     - cancel


### PR DESCRIPTION
@vendasta/external-apis

In discussion with business folks related to hearst we have a problem. They have started to migrate to our new apis and the apis they are using in their sdk are not supported in our new apis. 

Attempting to expose the undo cancell api by just adding another new keyword to the api. Implemented here: https://github.com/vendasta/api-gateway/pull/567/files

