### PR TITLE
Marketing customer list apis as deprecated

### DIFF
--- a/docs/Overview/Changelog.md
+++ b/docs/Overview/Changelog.md
@@ -2,8 +2,8 @@
 
 The platform is continuously evolving. This page lists the significant changes when they are announced. For more info on the statuses and release process see [Versioning](./Versioning.md)
 
-## 2024-09-26
-Deprecation of the Customer API. Current integrations are supported for deprecation period. No new development should occur against the Customer API. It is proposed to be replaced by the [UpsertCRMRecord](crm.json/paths/~1{namespace}~1{resourceTypeCode}/post) for the [new CRM](https://support.vendasta.com/hc/en-us/categories/24284629825559-CRM).
+## 2024-10-03
+Deprecation of the Customer API. Current integrations are supported for deprecation period. No new development should occur against the Customer API. It is proposed to be replaced by an API for new CRM that is still under development.
 
 ## 2024-02-27
 Mark `seoKeywords` field as deprecated in `SalesAccount` resource.

--- a/docs/Overview/Changelog.md
+++ b/docs/Overview/Changelog.md
@@ -1,9 +1,9 @@
 # Changelog
 
-The platform is continuously evolving. This page lists the significant changes when they are announced. For more info on the statuses and release process see [Versioning](./Versioning.md)
+The Vendasta Platform is continuously evolving. This page lists the significant changes when they are announced. For more info on the statuses and release process see [Versioning](./Versioning.md)
 
 ## 2024-10-03
-Deprecation of the Customer API. Current integrations are supported for deprecation period. No new development should occur against the Customer API. It is proposed to be replaced by an API for new CRM that is still under development.
+Deprecation of the Customer List API. Current integrations are supported for deprecation period. No new development should occur against the Customer API. The Vendasta Platform CRM API currently in `Trusted Testor` status replaces the Customer List API.
 
 ## 2024-02-27
 Mark `seoKeywords` field as deprecated in `SalesAccount` resource.

--- a/docs/Overview/Changelog.md
+++ b/docs/Overview/Changelog.md
@@ -2,6 +2,9 @@
 
 The platform is continuously evolving. This page lists the significant changes when they are announced. For more info on the statuses and release process see [Versioning](./Versioning.md)
 
+## 2024-09-26
+Deprecation of the Customer API. Current integrations are supported for deprecation period. No new development should occur against the Customer API. It is proposed to be replaced by the [UpsertCRMRecord](crm.json/paths/~1{namespace}~1{resourceTypeCode}/post) for the [new CRM](https://support.vendasta.com/hc/en-us/categories/24284629825559-CRM).
+
 ## 2024-02-27
 Mark `seoKeywords` field as deprecated in `SalesAccount` resource.
 

--- a/openapi/business/business.yaml
+++ b/openapi/business/business.yaml
@@ -134,7 +134,7 @@ paths:
                     readOnly: true
                 readOnly: true
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated`  - Proposed replacement: [Upsert CRM Record](https://developers.vendasta.com/platform/1de3f0654bc17-upsert-crm-record)
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - *coming soon*
 
         Used to create a new customer record within Business App.
 
@@ -231,7 +231,7 @@ paths:
                         description: The URI at which the next batch of customers can be gotten from
                         format: uri
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated`  - Proposed replacement: [Upsert CRM Record](https://developers.vendasta.com/platform/1de3f0654bc17-upsert-crm-record)
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - *coming soon*
 
         Produces a list of customers
       parameters:
@@ -329,7 +329,7 @@ paths:
       x-lifecycle:
         status: trustedTester
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated`  - Proposed replacement: [Upsert CRM Record](https://developers.vendasta.com/platform/1de3f0654bc17-upsert-crm-record)
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - *coming soon*
 
         Fetch the current values for the specified customer.
       parameters:
@@ -358,7 +358,7 @@ paths:
       x-lifecycle:
         status: trustedTester
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated`  - Proposed replacement: [Upsert CRM Record](https://developers.vendasta.com/platform/1de3f0654bc17-upsert-crm-record)
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - *coming soon*
 
         Delete the specified customer.
       parameters:
@@ -382,7 +382,7 @@ paths:
       tags:
         - Customers
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated`  - Proposed replacement: [Upsert CRM Record](https://developers.vendasta.com/platform/1de3f0654bc17-upsert-crm-record)
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - *coming soon*
 
         Update the existing customer.
         Only the root ID and type fields are required. All others are optional and will keep their original value if omitted.

--- a/openapi/business/business.yaml
+++ b/openapi/business/business.yaml
@@ -134,7 +134,7 @@ paths:
                     readOnly: true
                 readOnly: true
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated`  - Proposed replacement: [Upsert CRM Record](https://developers.vendasta.com/platform/1de3f0654bc17-upsert-crm-record)
 
         Used to create a new customer record within Business App.
 
@@ -200,6 +200,7 @@ paths:
                           id: AG-123
       tags:
         - Customers
+      deprecated: true
     get:
       summary: List Customers
       operationId: get-customers
@@ -230,7 +231,7 @@ paths:
                         description: The URI at which the next batch of customers can be gotten from
                         format: uri
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated`  - Proposed replacement: [Upsert CRM Record](https://developers.vendasta.com/platform/1de3f0654bc17-upsert-crm-record)
 
         Produces a list of customers
       parameters:
@@ -286,6 +287,7 @@ paths:
         - Customers
       x-lifecycle:
         status: trustedTester
+      deprecated: true
     options:
       summary: List valid HTTP verbs for /customers
       operationId: options-customers
@@ -296,6 +298,7 @@ paths:
       tags:
         - Options
         - Customers
+      deprecated: true
   '/customers/{id}':
     parameters:
       - schema:
@@ -326,7 +329,7 @@ paths:
       x-lifecycle:
         status: trustedTester
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated`  - Proposed replacement: [Upsert CRM Record](https://developers.vendasta.com/platform/1de3f0654bc17-upsert-crm-record)
 
         Fetch the current values for the specified customer.
       parameters:
@@ -343,6 +346,7 @@ paths:
             - customers
         - OAuth2Prod:
             - customers
+      deprecated: true
     delete:
       summary: Delete Customer
       tags:
@@ -354,7 +358,7 @@ paths:
       x-lifecycle:
         status: trustedTester
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated`  - Proposed replacement: [Upsert CRM Record](https://developers.vendasta.com/platform/1de3f0654bc17-upsert-crm-record)
 
         Delete the specified customer.
       parameters:
@@ -371,13 +375,14 @@ paths:
             - customers
         - OAuth2Prod:
             - customers
+      deprecated: true
     patch:
       summary: Update Customer
       operationId: patch-customers-id
       tags:
         - Customers
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Trusted Tester`
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated`  - Proposed replacement: [Upsert CRM Record](https://developers.vendasta.com/platform/1de3f0654bc17-upsert-crm-record)
 
         Update the existing customer.
         Only the root ID and type fields are required. All others are optional and will keep their original value if omitted.
@@ -432,6 +437,7 @@ paths:
               properties:
                 data:
                   $ref: '#/components/schemas/customers'
+      deprecated: true
     options:
       summary: 'List valid HTTP verbs for /customers/{id}'
       operationId: options-customers-id
@@ -442,6 +448,7 @@ paths:
       tags:
         - Options
         - Customers
+      deprecated: true
 components:
   securitySchemes:
     JWT:

--- a/openapi/business/business.yaml
+++ b/openapi/business/business.yaml
@@ -2,7 +2,10 @@ openapi: 3.0.0
 info:
   title: Business REST APIs
   version: '1.0'
-  description: APIs for managing data for a single business location.
+  description: |-
+    APIs for managing data for a single business location.
+
+    [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - Current Trusted Tester [Endpoint](../crm/crm.json/paths/~1{namespace}~1{resourceTypeCode}/post).
 servers:
   - url: 'https://prod.apigateway.co/business'
     description: Production
@@ -134,7 +137,7 @@ paths:
                     readOnly: true
                 readOnly: true
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - *coming soon*
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - Current Trusted Tester [Endpoint](../crm/crm.json/paths/~1{namespace}~1{resourceTypeCode}/post).
 
         Used to create a new customer record within Business App.
 
@@ -329,7 +332,7 @@ paths:
       x-lifecycle:
         status: trustedTester
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - *coming soon*
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - Current Trusted Tester [Endpoint](../crm/crm.json/paths/~1{namespace}~1{resourceTypeCode}/post)
 
         Fetch the current values for the specified customer.
       parameters:
@@ -382,7 +385,7 @@ paths:
       tags:
         - Customers
       description: |-
-        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - *coming soon*
+        [Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - Current Trusted Tester [Endpoint](../crm/crm.json/paths/~1{namespace}~1{resourceTypeCode}/post).
 
         Update the existing customer.
         Only the root ID and type fields are required. All others are optional and will keep their original value if omitted.

--- a/openapi/crm/crm.json
+++ b/openapi/crm/crm.json
@@ -542,7 +542,7 @@
             "description": "Bad Request"
           }
         },
-        "description": "[Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Proposed`\n\nCreate/update CRM contacts, companies or activities records.",
+        "description": "[Status](https://developers.vendasta.com/platform/ZG9jOjEwMTU2NTYy-versioning): `Deprecated` - Will be replaced by a new CRM API - *coming soon*\n\nCreate/update CRM contacts, companies or activities records.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -694,8 +694,10 @@
           "description": ""
         },
         "x-lifecycle": {
-          "status": "proposed"
-        }
+          "status": "deprecated",
+          "deprecated": "2024-10-03"
+        },
+        "deprecated": true
       }
     }
   },


### PR DESCRIPTION
@vendasta/external-apis

People are often getting confused about the legacy Customer LIst endpoints and the new CRM endpoints. The API was deprecated last year, but I missed merging this earlier.
