### PR TITLE
create section for external grpc documentation in the developer center

### DIFF
--- a/toc.json
+++ b/toc.json
@@ -349,9 +349,9 @@
       "title": "Vendasta APIs"
     },
     {
-      "type": "item",
+      "type": "group",
       "title": "Vendasta APIs",
-      "uri": "openapi/grpc_api.swagger.json"
+      "items": []
     },
     {
       "type": "divider",
@@ -361,15 +361,6 @@
       "type": "item",
       "title": "Overview",
       "uri": "https://developers.vendasta.com/api/legacy"
-    },
-    {
-      "type": "divider",
-      "title": "GRPC OpenAPI"
-    },
-    {
-      "type": "group",
-      "title": "GRPC OpenAPI Specifications",
-      "items": []
     }
   ]
 }

--- a/toc.json
+++ b/toc.json
@@ -361,6 +361,15 @@
       "type": "item",
       "title": "Overview",
       "uri": "https://developers.vendasta.com/api/legacy"
+    },
+    {
+      "type": "divider",
+      "title": "GRPC OpenAPI"
+    },
+    {
+      "type": "group",
+      "title": "GRPC OpenAPI Specifications",
+      "items": []
     }
   ]
 }


### PR DESCRIPTION
The documentation for the GRPC services cannot be rendered under a single file as the file is large and Stoplight seams to have limitation.  To overcome this limitation, for each service a separate file is to be generated.  An item entry is required in the toc.json for the each of the file.  This PR create a section and items based on the files generated can be added to this section. 


@vendasta/external-apis

**TODO**:
- [ ] Review the [pre release checklist](https://vendasta.jira.com/wiki/spaces/API/pages/1651769533/Pre+Release+Checks)

<!-- tag teams, people -->
@vendasta/marina @vendasta/phoenix 
