### PR TITLE
PHNX-1946 document filter[searchTerm] on List Business Locations

### DIFF
--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -258,6 +258,14 @@ paths:
           in: query
           name: 'filter[id]'
           description: 'Return accounts for given ids. For this filter ,We are not supporting pagination.'
+        - schema:
+            type: string
+            example: 'Acme Plumbing'
+          in: query
+          name: 'filter[searchTerm]'
+          description: |-
+            Performs a full-text search across business location data (such as name, phone numbers, and address). The results order is not affected by the quality of this match — use `sort` to control ordering.
+            Cannot be combined with `filter[id]`; the request will be rejected if both are provided.
       security:
         - OAuth2Demo:
             - business


### PR DESCRIPTION
## Summary

Documents the new `filter[searchTerm]` query parameter on `GET /platform/businessLocations`. Mirrors the implementation change in [vendasta/api-gateway#671](https://github.com/vendasta/api-gateway/pull/671).

## Why

A partner reported that the only way to discover a `businessLocationID` today is to call the list endpoint with `filter[businessPartner.id]` and page through every location. The new `filter[searchTerm]` parameter lets consumers find a business by name, phone number, or address in a single call.

## Documented behavior

- Optional query parameter, single string value, full-text search across name / phone / address.
- Result ordering is **not** influenced by match relevance — consumers should use `sort` to control ordering (mirrors the `/users` `filter[searchTerm]` phrasing).
- Cannot be combined with `filter[id]`; the request is rejected (`400`) when both are provided.

## Related

- Implementation PR: [vendasta/api-gateway#671](https://github.com/vendasta/api-gateway/pull/671)
- Jira: [PHNX-1946](https://vendasta.jira.com/browse/PHNX-1946)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PHNX-1946]: https://vendasta.jira.com/browse/PHNX-1946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ