### PR TITLE
docs(salesAccounts): add primaryOperatingLanguage to salesAccounts schema

### DIFF
--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -5172,6 +5172,11 @@ components:
                 x-stoplight:
                   id: t1gp8neeat4ym
                 type: string
+            primaryOperatingLanguage:
+              type: string
+              readOnly: true
+              description: 'The primary language in which this business operates, as a BCP 47 language tag (e.g. "en", "it", "fr-CA"). Mirrored from the salesAccounts record; set it there to change it. Returns "en" when unset.'
+              example: en
         relationships:
           type: object
           properties:
@@ -6679,7 +6684,7 @@ components:
               description: Administration notes for the account.
             primaryOperatingLanguage:
               type: string
-              description: 'The primary language in which this business operates, as a BCP 47 language tag (e.g. "en", "it", "fr-CA"). Empty means unset; fallback behaviour when unset is determined by each downstream consumer.'
+              description: 'The primary language in which this business operates, as a BCP 47 language tag (e.g. "en", "it", "fr-CA"). Returns "en" when unset.'
               example: en
             socialUrls:
               type: object

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -6679,7 +6679,7 @@ components:
               description: Administration notes for the account.
             primaryOperatingLanguage:
               type: string
-              description: 'The primary language in which this business operates, as a BCP 47 language tag (e.g. "en", "it", "fr-CA"). Empty means unset; downstream consumers default to "en".'
+              description: 'The primary language in which this business operates, as a BCP 47 language tag (e.g. "en", "it", "fr-CA"). Empty means unset; fallback behaviour when unset is determined by each downstream consumer.'
               example: en
             socialUrls:
               type: object

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -6677,6 +6677,10 @@ components:
               x-stoplight:
                 id: tnzahuoq5fsyi
               description: Administration notes for the account.
+            primaryOperatingLanguage:
+              type: string
+              description: 'The primary language in which this business operates, as a BCP 47 language tag (e.g. "en", "it", "fr-CA"). Empty means unset; downstream consumers default to "en".'
+              example: en
             socialUrls:
               type: object
               x-stoplight:

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -6684,7 +6684,7 @@ components:
               description: Administration notes for the account.
             primaryOperatingLanguage:
               type: string
-              description: 'The primary language in which this business operates, as a BCP 47 language tag (e.g. "en", "it", "fr-CA"). Returns "en" when unset.'
+              description: 'The primary language in which this business operates, as a BCP 47 language tag (e.g. "en", "it", "fr-CA"). Returns "en" when unset. On write, an empty or omitted value is ignored (it will not clear an existing value set via Business Profile).'
               example: en
             socialUrls:
               type: object


### PR DESCRIPTION
## Summary

Adds `primaryOperatingLanguage` (BCP 47 language tag) to the `salesAccounts` schema in the platform OpenAPI spec.

**Depends on:** vendasta/api-gateway#688 — the field is wired up in the API implementation there. This doc PR should land together with (or after) that one.

## What changed

- `openapi/platform/platform.yaml` — adds `primaryOperatingLanguage: string` property to the `salesAccounts` schema, between `adminNotes` and `socialUrls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)