### PR TITLE
Update references from "Social Marketing" to "Social AI" (SM-3725)

### DIFF
--- a/docs/Guides/Sell/FindSKU.md
+++ b/docs/Guides/Sell/FindSKU.md
@@ -22,7 +22,7 @@ Inbox Pro — AI-assisted web chat lead capture | MP-DKT6XHPM6NCCDNK2TPDPVD3PG3V
 Campaigns Pro | MP-ZGJ6V4QRP77WPMDKXS6VDRNX58Q42P7P | MP-WF5KS7FHTGV4LR5DBQ4D6XKCCDB5B6G7
 Local SEO Pro | MS:EDITION-CFH5CKHC | MS:EDITION-MXWLTQPN
 Reputation AI Premium | RM:EDITION-JFRPLQPN | RM:EDITION-BFXF8W8Q
-Social Marketing Pro | SM | SM
+Social AI Pro | SM | SM
 
 
 ### Reputation AI
@@ -57,7 +57,7 @@ United States - SMS 200 | A-NBZXMTZR3D | N/A
 United States - SMS 50 | A-FL4L4THJZV | N/A
 United States - SMS 500 | A-4GTDC7X8V2 | N/A
 
-### Social Marketing
+### Social AI
 
 Product | Production SKU | Demo SKU
 --------|----------------|---------

--- a/docs/Guides/Social/socialProfiles.md
+++ b/docs/Guides/Social/socialProfiles.md
@@ -3,7 +3,7 @@ tags: [Social Profiles]
 ---
 # Getting Social Profiles
 
-A `Social Profile` represents an account on a social network that has been connected to a specific Business Location in [Social Marketing](https://support.vendasta.com/hc/en-us/sections/4406957071383-Social-Marketing).
+A `Social Profile` represents an account on a social network that has been connected to a specific Business Location in [Social AI](https://support.vendasta.com/hc/en-us/sections/4406957071383-Social-Marketing).
 
 > For info on Business Locations see the [Businesses guide](../Accounts.md).
 
@@ -15,7 +15,7 @@ Create an access token with either the `social` or `business` scopes following t
 
 ### Fetching All Connected Social Profiles For A Business
 
-Social Profiles for a single Business Location can be fetched using its ID and an appropriate Authorization token. The data can be used to verify what a business has connected for use in Social Marketing and its current status. Future APIs that are in development will use the IDs obtained from this endpoint to let you access additional functionality.
+Social Profiles for a single Business Location can be fetched using its ID and an appropriate Authorization token. The data can be used to verify what a business has connected for use in Social AI and its current status. Future APIs that are in development will use the IDs obtained from this endpoint to let you access additional functionality.
 
 This example request will enable you to get the first 25 connected Social Profiles for a Business Location, and if there are more, will give you a cursor so you can access the rest. 
 

--- a/docs/Overview/Changelog.md
+++ b/docs/Overview/Changelog.md
@@ -2,6 +2,9 @@
 
 The Vendasta Platform is continuously evolving. This page lists the significant changes when they are announced. For more info on the statuses and release process see [Versioning](./Versioning.md)
 
+## 2025-07-14
+Update references from "Social Marketing" to "Social AI"
+
 ## 2025-11-18
 Removed get and create sales contacts (/platform/salesContacts). They have been replaced with CRM contacts.
 Removed proposal builder APIs. The product is no longer supported.

--- a/docs/Overview/ProductOverview.md
+++ b/docs/Overview/ProductOverview.md
@@ -39,7 +39,7 @@ See what your clients' customers are saying across 50+ review sources
 <img src="https://raw.githubusercontent.com/vendasta/api-gateway-docs/master/docs/Overview/logos/logoSM.png" alt="Social Media Management" class="sl-image" style="width:75px"/>
 </td><td>
 
-## Social Marketing
+## Social AI
 
 ### Social Connections
 

--- a/docs/SSO/Navigation-Links.md
+++ b/docs/SSO/Navigation-Links.md
@@ -17,7 +17,7 @@ that will send users to pages in the Vendasta platform and marketplace products.
 >
 > Advertising Intelligence  -> `https://sso-api-prod.apigateway.co/service-gateway?serviceProviderId=MP-94072e44d5364872b672d7ab4fc7a7e8&account_id=AG-1234567`
 >
-> Social Marketing -> `https://sso-api-prod.apigateway.co/service-gateway?serviceProviderId=SM&account_id=AG-1234567`
+> Social AI -> `https://sso-api-prod.apigateway.co/service-gateway?serviceProviderId=SM&account_id=AG-1234567`
 >
 > Customer Voice -> `https://sso-api-prod.apigateway.co/service-gateway?serviceProviderId=MP-c4974d390a044c28aec31e421aa662b2&account_id=AG-1234567`
 >

--- a/openapi/social/social.yaml
+++ b/openapi/social/social.yaml
@@ -205,7 +205,7 @@ components:
           tokenUrl: 'https://sso-api-demo.apigateway.co/oauth2/token'
           scopes:
             business: Read-write access to business details
-            social: Read-write access to Social Marketing APIs
+            social: Read-write access to Social AI APIs
     OAuth2Prod:
       type: oauth2
       flows:
@@ -214,7 +214,7 @@ components:
           tokenUrl: 'https://sso-api-prod.apigateway.co/oauth2/token'
           scopes:
             business: Read-write access to business details
-            social: Read-write access to Social Marketing APIs
+            social: Read-write access to Social AI APIs
   schemas:
     socialProfiles:
       title: Social Profiles

--- a/toc.json
+++ b/toc.json
@@ -322,7 +322,7 @@
     },
     {
       "type": "item",
-      "title": "Social Marketing APIs",
+      "title": "Social AI APIs",
       "uri": "openapi/social/social.yaml"
     },
     {


### PR DESCRIPTION
## Summary
- Renames "Social Marketing" to "Social AI" across all API gateway documentation
- Mirrors the pattern from PR #237 (Reputation Management → Reputation AI)
- Updates SKU tables, product overview, SSO navigation links, social profiles guide, OpenAPI specs, TOC, and changelog

## Jira
[SM-3725](https://vendasta.jira.com/browse/SM-3725)

## Files changed (7)
| File | Changes |
|------|---------|
| `docs/Guides/Sell/FindSKU.md` | "Social Marketing Pro" → "Social AI Pro", section header |
| `docs/Overview/ProductOverview.md` | Section header |
| `docs/SSO/Navigation-Links.md` | SSO link label |
| `docs/Guides/Social/socialProfiles.md` | Product name references (2) |
| `toc.json` | "Social Marketing APIs" → "Social AI APIs" |
| `openapi/social/social.yaml` | OAuth scope descriptions (2) |
| `docs/Overview/Changelog.md` | Added changelog entry |

## Test plan
- [ ] Verify Stoplight renders the updated docs correctly
- [ ] Verify OpenAPI spec validates with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@vendasta/tots 
@vendasta/external-apis

[SM-3725]: https://vendasta.jira.com/browse/SM-3725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ