### PR TITLE
Update languageLocaleCode pattern and add Italian language options

### DIFF
--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -6021,7 +6021,7 @@ components:
               readOnly: true
             languageLocaleCode:
               type: string
-              pattern: '^[a-z]{2}-[A-Z]{2}$'
+              pattern: '^[a-z]{2}-[A-Z]{2}?$'
               example: en-US
               description: |-
                 The local language that content should be displayed to this user in.
@@ -6033,9 +6033,11 @@ components:
                 Examples:
                 - `en-US` English (US)
                 - `fr-FR` French (France)
-                - `cs-Cz` Czech (Czech Republic)
+                - `cs-CZ` Czech (Czech Republic)
                 - `de-DE` German (Germany)
                 - `nl-BE` Dutch (Belgium)
+                - `it` Italian
+                - `it-IT` Italian (Italy)
             phoneNumbersSet:
               type: boolean
             phoneNumbers:

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -6021,7 +6021,7 @@ components:
               readOnly: true
             languageLocaleCode:
               type: string
-              pattern: '^[a-z]{2}-[A-Z]{2}?$'
+              pattern: '^[a-z]{2}(-[A-Z]{2})?$'
               example: en-US
               description: |-
                 The local language that content should be displayed to this user in.

--- a/openapi/platform/platform.yaml
+++ b/openapi/platform/platform.yaml
@@ -6037,7 +6037,6 @@ components:
                 - `de-DE` German (Germany)
                 - `nl-BE` Dutch (Belgium)
                 - `it` Italian
-                - `it-IT` Italian (Italy)
             phoneNumbersSet:
               type: boolean
             phoneNumbers:


### PR DESCRIPTION
## changes made:
One pattern: line, and it's the (-[A-Z]{2})? version → both it and it-IT pass.
One Czech line, spelled cs-CZ (uppercase region) → old cs-Cz typo gone.
Examples include both it and it-IT.

## findings :
Where it BLOCKS 
1. The REST "create user" API — api-gateway → openapi/platform.yaml
On every request, a validator reads a rule baked into the running app: the pattern ^[a-z]{2}-[A-Z]{2}$. That rule forces a region, so it-IT passes but plain it is rejected (400 error).

2. The Customer Voice template locale — templates → internal/lang/service.go
So it checks the value against a fixed list that contains only bare it. Since there's no it-IT in the list, it-IT is rejected ("locale not supported").

@vendasta/external-apis
@vendasta/np-easy 

([CRMAAS-3053](https://vendasta.jira.com/browse/CRMAAS-3053))

[CRMAAS-3053]: https://vendasta.jira.com/browse/CRMAAS-3053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ