### PR TITLE
MRNA-2460: document the 409 uniqueness conflict on CRM record writes

### DIFF
--- a/docs/Guides/CRM/crm.md
+++ b/docs/Guides/CRM/crm.md
@@ -189,6 +189,48 @@ The API performs several levels of validation:
     *   **Phones:** Should follow E.164 format for best results.
 3.  **Dropdown Validation:** Values for dropdown fields must match one of the valid options returned by the **Get field options** endpoint.
 
+### Unique field conflicts (`409`)
+
+Some fields are **enforced as unique** within a namespace — no two records may hold the same value. Writing a value that another record already owns is rejected with `409 Conflict`, and **no part of the request is applied**.
+
+The most common cause is a person or company existing as two records that have split their identifying fields between them. For example, one contact holds the email address while a second holds the `external_id`. Sending both values in one request matches the first record and then collides with the second.
+
+The response names the fields responsible and the records that already hold each value:
+
+```json
+{
+  "error": "The following field values are already used by other records in AG-EXAMPLE. Remove them from the request to continue.",
+  "fieldViolations": {
+    "uniqueness": {
+      "description": "Values that violate a unique constraint and must be removed to proceed.",
+      "values": ["external_id", "standard__email"]
+    }
+  },
+  "metadata": {
+    "external_id": "Already used by: ContactID-bbbbbbbb-....",
+    "standard__email": "Already used by: ContactID-aaaaaaaa-...."
+  }
+}
+```
+
+#### Recovering from a conflict
+
+1.  Read the field IDs from `fieldViolations.uniqueness.values`.
+2.  **Remove those fields** from your `fields` array.
+3.  Resend the request. The remaining fields are written normally.
+
+You keep the update, at the cost of not setting the conflicting identifier on that record.
+
+#### Which fields can cause a `409`
+
+Only fields with **enforced** uniqueness. Fields with *warning-level* uniqueness — notably `standard__phone_number` — are never the cause and never appear in the response.
+
+**Key takeaway:** Never drop a phone number in response to a `409`. It cannot be the field that caused the conflict, and removing it loses the ability to contact the customer.
+
+#### Treat the cause, not just the symptom
+
+A `409` is a signal that two records describe the same real-world entity. The IDs in `metadata` tell you which ones. Dropping fields keeps your sync running, but the duplicates remain and the same request will conflict again next time. Use those IDs to merge or reconcile the records so the conflict stops recurring.
+
 ### Limitations
 
 -   **String Length:** Standard text fields typically have a 255-character limit unless otherwise specified in the schema.

--- a/openapi/crm/crm.json
+++ b/openapi/crm/crm.json
@@ -743,6 +743,36 @@
           },
           "400": {
             "description": "Bad Request"
+          },
+          "409": {
+            "description": "Conflict. A submitted value is already used by a different CRM record in a field the CRM enforces as unique. The response names the fields responsible and the records that hold the values, so the request can be retried without them.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UniquenessConflictError"
+                },
+                "examples": {
+                  "Email and external_id owned by two different records": {
+                    "value": {
+                      "error": "The following field values are already used by other records in AG-EXAMPLE. Remove them from the request to continue.",
+                      "fieldViolations": {
+                        "uniqueness": {
+                          "description": "Values that violate a unique constraint and must be removed to proceed.",
+                          "values": [
+                            "external_id",
+                            "standard__email"
+                          ]
+                        }
+                      },
+                      "metadata": {
+                        "external_id": "Already used by: ContactID-00000000-0000-4000-8000-000000000001.",
+                        "standard__email": "Already used by: ContactID-00000000-0000-4000-8000-000000000002."
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -798,6 +828,36 @@
           },
           "400": {
             "description": "Bad Request"
+          },
+          "409": {
+            "description": "Conflict. A submitted value is already used by a different CRM record in a field the CRM enforces as unique. The response names the fields responsible and the records that hold the values, so the request can be retried without them.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UniquenessConflictError"
+                },
+                "examples": {
+                  "Email and external_id owned by two different records": {
+                    "value": {
+                      "error": "The following field values are already used by other records in AG-EXAMPLE. Remove them from the request to continue.",
+                      "fieldViolations": {
+                        "uniqueness": {
+                          "description": "Values that violate a unique constraint and must be removed to proceed.",
+                          "values": [
+                            "external_id",
+                            "standard__email"
+                          ]
+                        }
+                      },
+                      "metadata": {
+                        "external_id": "Already used by: ContactID-00000000-0000-4000-8000-000000000001.",
+                        "standard__email": "Already used by: ContactID-00000000-0000-4000-8000-000000000002."
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1004,6 +1064,36 @@
           },
           "400": {
             "description": "Bad Request"
+          },
+          "409": {
+            "description": "Conflict. A submitted value is already used by a different CRM record in a field the CRM enforces as unique. The response names the fields responsible and the records that hold the values, so the request can be retried without them.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UniquenessConflictError"
+                },
+                "examples": {
+                  "Email and external_id owned by two different records": {
+                    "value": {
+                      "error": "The following field values are already used by other records in AG-EXAMPLE. Remove them from the request to continue.",
+                      "fieldViolations": {
+                        "uniqueness": {
+                          "description": "Values that violate a unique constraint and must be removed to proceed.",
+                          "values": [
+                            "external_id",
+                            "standard__email"
+                          ]
+                        }
+                      },
+                      "metadata": {
+                        "external_id": "Already used by: ContactID-00000000-0000-4000-8000-000000000001.",
+                        "standard__email": "Already used by: ContactID-00000000-0000-4000-8000-000000000002."
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -4113,6 +4203,46 @@
             }
           }
         ]
+      },
+      "UniquenessConflictError": {
+        "type": "object",
+        "title": "Uniqueness Conflict Error",
+        "description": "Returned when a submitted value is already held by a different CRM record in a field the CRM enforces as unique. Only fields with *enforced* uniqueness are reported — fields with warning-level uniqueness, such as `standard__phone_number`, are never the cause of this error and are never listed. To recover, remove the reported fields from the request and send it again; the rest of the record is written normally.",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Human readable summary of the conflict."
+          },
+          "fieldViolations": {
+            "type": "object",
+            "description": "Groups the conflict by section. Uniqueness conflicts use the `uniqueness` key.",
+            "properties": {
+              "uniqueness": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "description": "Explains what the listed values have in common."
+                  },
+                  "values": {
+                    "type": "array",
+                    "description": "Field IDs that must be removed from the request. Uses the same field IDs you submitted, including root fields such as `external_id`.",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "description": "One entry per conflicting field, naming the existing CRM records that already hold the submitted value. Use these IDs to decide whether the records should be merged.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
       }
     },
     "securitySchemes": {


### PR DESCRIPTION
@vendasta/external-apis

Ports the `409` documentation from the new developer portal (developer-center-docs#20) to this portal, so both describe the behaviour identically.

## What

`CreateCrmRecord`, `UpsertCrmRecord` and `UpdateCrmRecord` return `409` when a submitted value is already held by a different CRM record in a field the CRM enforces as unique — but the spec listed only `200` and `400`. Developers had no indication the response existed.

- **`openapi/crm/crm.json`** — adds a `UniquenessConflictError` schema and a `409` response to those three operations.
- **`docs/Guides/CRM/crm.md`** — adds a **Unique field conflicts (`409`)** section under *Data Integrity and Validation*, covering what a schema cannot convey: only *enforced*-unique fields are listed (`standard__phone_number` never appears), recovery is to drop the named fields and resend, and the record IDs in `metadata` identify duplicates worth merging rather than working around.

## Note on the example values

The equivalent change in `developer-center-docs` used values captured against demo. That repository is private and this one is public, so the namespace and contact IDs here are placeholders (`AG-EXAMPLE`, `ContactID-00000000-…`). Wording is otherwise identical between the two portals.

## Verification

- `openapi/crm/crm.json` parses, and re-serialising it reproduces the file byte-for-byte — the diff is purely additive, with no reformatting noise.
- Guide heading levels and placement match the new portal.
- Spectral was not run locally: `.spectral.mjs` re-exports a remote Stoplight ruleset, so CI/Stoplight is the first lint pass.
- No `toc.json` change needed — the section was added to an existing page.

## Proof

<img width="1524" height="821" alt="image" src="https://github.com/user-attachments/assets/f797fd4f-d8e0-48ee-af3e-7c08a7f231d2" />



https://vendasta.jira.com/browse/MRNA-2460

